### PR TITLE
Updating the identifier search query to utilized the collation index …

### DIFF
--- a/impl/search_util.py
+++ b/impl/search_util.py
@@ -288,7 +288,7 @@ def formulateQuery(
                         v = "doi:" + v
                 if v == None:
                     v = value
-            filters.append(django.db.models.Q(identifier__startswith=v))
+            filters.append(django.db.models.Q(identifier__istartswith=v))
         elif column == "identifierType":
             if isinstance(value, basestring):
                 value = [value]


### PR DESCRIPTION
…and drop the `BINARY` keyword

Updating the identifier search query to utilized the collation index and drop the `BINARY` keyword
- improves search speed

Reference: #159 #160