### PR TITLE
Bug/189

### DIFF
--- a/ezidapp/management/commands/proc-link-checker-update.py
+++ b/ezidapp/management/commands/proc-link-checker-update.py
@@ -46,7 +46,7 @@ class Command(ezidapp.management.commands.proc_base.AsyncProcessingCommand):
 
     def run(self):
         if self.opt.pagesize <= 0:
-            self.opt.pagesize = Command._page_size
+            self.opt.pagesize = 1
         if not self.opt.debug:
             if self.resultsUploadSameTimeOfDay:
                 self.sleep(self._sameTimeOfDayDelta())


### PR DESCRIPTION
The issue was attempted transaction on the "search" database alias, which no longer exists.

Added --pagesize argument to proc-link-checker-update, defaulting to 100,000 which seems to offer a reasonable balance between performance and memory use.