### PR TITLE
Typo in model reference. Fixes #206

### DIFF
--- a/ezidapp/management/commands/proc-binder.py
+++ b/ezidapp/management/commands/proc-binder.py
@@ -28,7 +28,10 @@ class Command(ezidapp.management.commands.proc_base.AsyncProcessingCommand):
         impl.noid_egg.setElements(id_str, metadata)
 
     def update(self, task_model):
-        id_str = task_model.ref_identifier.identifier
+        '''
+        task_model: BinderQueue
+        '''
+        id_str = task_model.refIdentifier.identifier
         metadata = task_model.refIdentifier.metadata
 
         m = impl.noid_egg.getElements(id_str)


### PR DESCRIPTION
Probably fixes #206, directly addresses log messages like:
```
eb 15 09:55:31 uc3-ezidui02x2-stg ezid-proc-errorlog: DEBUG ezidapp.management.commands.proc_base proc_base 2538 140498724128576 Binder: Processing task: update
Feb 15 09:55:31 uc3-ezidui02x2-stg ezid-proc-errorlog: ERROR ezidapp.management.commands.proc_base proc_base 2538 140498724128576 Binder: Task registration error
Feb 15 09:55:31 uc3-ezidui02x2-stg ezid-proc-errorlog: Traceback (most recent call last):
Feb 15 09:55:31 uc3-ezidui02x2-stg ezid-proc-errorlog: File "/apps/ezid/ezid/ezidapp/management/commands/proc_base.py", line 99, in run
Feb 15 09:55:31 uc3-ezidui02x2-stg ezid-proc-errorlog: self.do_task(task_model)
Feb 15 09:55:31 uc3-ezidui02x2-stg ezid-proc-errorlog: File "/apps/ezid/ezid/ezidapp/management/commands/proc_base.py", line 173, in do_task
Feb 15 09:55:31 uc3-ezidui02x2-stg ezid-proc-errorlog: self.update(task_model)
Feb 15 09:55:31 uc3-ezidui02x2-stg ezid-proc-errorlog: File "/apps/ezid/ezid/ezidapp/management/commands/proc-binder.py", line 31, in update
Feb 15 09:55:31 uc3-ezidui02x2-stg ezid-proc-errorlog: id_str = task_model.ref_identifier.identifier
Feb 15 09:55:31 uc3-ezidui02x2-stg ezid-proc-errorlog: AttributeError: 'BinderQueue' object has no attribute 'ref_identifier'
```