### PR TITLE
Proc refine

### DIFF
--- a/settings/settings.py.j2
+++ b/settings/settings.py.j2
@@ -147,7 +147,14 @@ DAEMONS_STATUS_ENABLED = True
 DAEMONS_BATCH_SLEEP = 1
 # Sleep after all batches are done. This sleep is performed when there is no more work
 # to do, but new work is expected to be added shortly.
-DAEMONS_IDLE_SLEEP = 60
+DAEMONS_IDLE_SLEEP = 1
+# Reset database connections after this many seconds.
+# When sleeping, if its been more than this many seconds since the
+# last time the connection was reset, then reset database connections
+# This significantly reduces the disconnect / connect activity of background
+# processes and allows for a shorter DAEMONS_IDLE_SLEEP (suggest 1 second)
+# This value can be set to zero to disable.
+DAEMONS_IDLE_DB_RECONNECT = 600
 # Sleep after the work is done, for use in processing that is not time critical.
 DAEMONS_LONG_SLEEP = 60 * 60 * 24
 # Limit the number of results in each queryset. This value becomes a LIMIT clause in the


### PR DESCRIPTION
Adjust `proc_base` by:

1. Gracefully handle termination or interruption of the background process
2. Don't reset database connection until at least `settings.DAEMONS_IDLE_DB_RECONNECT`

The later reduces the db connect/reconnect chatter and allows for much shorter sleep cycles of the daemons, which in turn allows for improved responsiveness of background jobs, e.g. `DAEMONS_IDLE_SLEEP` can be set to 1 instead of the default 60.