### PR TITLE
proc-expunge: Delete identifiers directly

### DIFF
--- a/ezidapp/management/commands/proc-expunge.py
+++ b/ezidapp/management/commands/proc-expunge.py
@@ -19,6 +19,7 @@ import urllib.response
 import django.conf
 import django.conf
 import django.db
+import django.db.transaction
 
 import ezidapp.management.commands.proc_base
 import ezidapp.models.identifier
@@ -62,7 +63,8 @@ class Command(ezidapp.management.commands.proc_base.AsyncProcessingCommand):
                 continue
 
             for si in qs:
-                impl.enqueue.enqueue(si, "delete", updateExternalServices=True)
-                si.delete()
+                with django.db.transaction.atomic():
+                    impl.enqueue.enqueue(si, "delete", updateExternalServices=True)
+                    si.delete()
 
             self.sleep(django.conf.settings.DAEMONS_BATCH_SLEEP)

--- a/ezidapp/management/commands/proc-expunge.py
+++ b/ezidapp/management/commands/proc-expunge.py
@@ -27,6 +27,8 @@ import ezidapp.models.news_feed
 import ezidapp.models.shoulder
 from django.db.models import Q
 
+import impl.enqueue
+import impl.ezid
 
 log = logging.getLogger(__name__)
 
@@ -38,19 +40,11 @@ class Command(ezidapp.management.commands.proc_base.AsyncProcessingCommand):
 
     def __init__(self):
         super().__init__()
-        auth_handler = urllib.request.HTTPBasicAuthHandler()
-        auth_handler.add_password(
-            "EZID",
-            django.conf.settings.EZID_BASE_URL,
-            "admin",
-            django.conf.settings.ADMIN_PASSWORD,
-        )
-        self.opener = urllib.request.build_opener()
-        self.opener.add_handler(auth_handler)
 
     def run(self):
         while not self.terminated():
-            max_age_ts = int(time.time()) - django.conf.settings.DAEMONS_EXPUNGE_MAX_AGE_SEC
+            max_age_ts = int(
+                time.time()) - django.conf.settings.DAEMONS_EXPUNGE_MAX_AGE_SEC
             # TODO: This is a heavy query which can be optimized with better indexes or
             # flags in the DB.
             qs = (
@@ -59,8 +53,8 @@ class Command(ezidapp.management.commands.proc_base.AsyncProcessingCommand):
                     | Q(identifier__startswith=django.conf.settings.SHOULDERS_DOI_TEST)
                     | Q(identifier__startswith=django.conf.settings.SHOULDERS_CROSSREF_TEST)
                 )
-                .filter(createTime__lte=max_age_ts)
-                .only("identifier")[: django.conf.settings.DAEMONS_MAX_BATCH_SIZE]
+                    .filter(createTime__lte=max_age_ts)
+                    .only("identifier")[: django.conf.settings.DAEMONS_MAX_BATCH_SIZE]
             )
 
             if not qs:
@@ -68,29 +62,7 @@ class Command(ezidapp.management.commands.proc_base.AsyncProcessingCommand):
                 continue
 
             for si in qs:
-                try:
-                    self.deleteIdentifier(si.identifier)
-                except urllib.error.HTTPError as e:
-                    log.exception(f'{e.read()}: {str(e)}')
-                except Exception:
-                    log.exception(f'Exception on expunge of identifier: {si.identifier}')
+                impl.enqueue.enqueue(si, "delete", updateExternalServices=True)
+                si.delete()
 
             self.sleep(django.conf.settings.DAEMONS_BATCH_SLEEP)
-
-    def deleteIdentifier(self, id_str):
-        """Though we read identifiers directly from the EZID database, to avoid
-        conflicts with the corresponding running system we don't delete identifiers
-        directly, but ask the system to do so.
-        """
-        log.debug(f'Expunging identifier: {id_str}')
-        request = urllib.request.Request(
-            '{}/id/{}'.format(
-                django.conf.settings.EZID_BASE_URL,
-                urllib.parse.quote(id_str, ':/'),
-            )
-        )
-        request.get_method = lambda: "DELETE"
-        with self.opener.open(request) as response:
-            body_str = response.read().decode('utf-8', errors='replace')
-            if not body_str.startswith("success:"):
-                self.raise_command_error(f"Unexpected response: {body_str}")


### PR DESCRIPTION
Since expunge is now a mgmt cmd, we can delete test identifiers
directly instead of going through the REST API.