### PR TITLE
Fix 297

### DIFF
--- a/ezidapp/management/commands/proc-crossref.py
+++ b/ezidapp/management/commands/proc-crossref.py
@@ -111,12 +111,16 @@ class Command(ezidapp.management.commands.proc_base.AsyncProcessingCommand):
 
         url = 'http://datacite.org/invalidDOI' if op_str == self.queue.DELETE else ref_id.target
 
+        # withdrawTitles is set to True if:
+        #  The current operation is a DELETE
+        #  OR
+        #  the identifier is unvailable, meaning the identified resource is not available
         submission, body, batchId = self._buildDeposit(
             meta_dict['crossref'],
             ref_id.owner.username,
             id_base_str,
             url,
-            withdrawTitles=(op_str == self.queue.DELETE or not ref_id.isReserved),
+            withdrawTitles=(op_str == self.queue.DELETE or ref_id.isUnavailable),
         )
 
         self._submitDeposit(submission, batchId, id_base_str)

--- a/ezidapp/models/async_queue.py
+++ b/ezidapp/models/async_queue.py
@@ -40,8 +40,11 @@ class AsyncQueueBase(django.db.models.Model):
         )
 
     # Operation to perform
+    # A new identifier is being created
     CREATE = "C"
+    # An existing identifier is being updated
     UPDATE = "U"
+    # An existing identifier is being deleted
     DELETE = "D"
     OPERATION_CODE_TO_LABEL_DICT = {CREATE: "create", UPDATE: "update", DELETE: "delete"}
     OPERATION_LABEL_TO_CODE_DICT = {v: k for k, v in OPERATION_CODE_TO_LABEL_DICT.items()}


### PR DESCRIPTION
Corrects crossref withdrawn status to be due to identifier deletion or the identified resource being unavailable.