### PR TITLE
Uncomment s() method

### DIFF
--- a/ezidapp/management/commands/proc-link-checker.py
+++ b/ezidapp/management/commands/proc-link-checker.py
@@ -185,12 +185,12 @@ class Command(ezidapp.management.commands.proc_base.AsyncProcessingCommand):
                 self.sleep(60)
             firstRound = False
 
-    # @staticmethod
-    # def s(n):
-    #     if n != 1:
-    #         return "s"
-    #     else:
-    #         return ""
+    @staticmethod
+    def s(n):
+        if n != 1:
+            return "s"
+        else:
+            return ""
 
     @staticmethod
     def toHms(seconds):


### PR DESCRIPTION
This method was commented out which caused an error in logging which in turned crashed linkchecker since it was expecting this method to be available.