### PR TITLE
set log level by parameter

### DIFF
--- a/settings/settings.py.j2
+++ b/settings/settings.py.j2
@@ -230,25 +230,25 @@ logging.config.dictConfig(
         },
         'handlers': {
             'console': {
-                'level': 'DEBUG',
+                'level': '{{ log_level }}',
                 'class': 'logging.StreamHandler',
                 'formatter': 'verbose',
                 'stream': sys.stdout,
             },
             'request_log': {
-                'level': 'DEBUG',
+                'level': '{{ log_level }}',
                 'class': 'logging.FileHandler',
                 'filename': LOG_DIR / 'request.log',
                 'formatter': 'simple',
             },
             'trace_log': {
-                'level': 'DEBUG',
+                'level': '{{ log_level }}',
                 'class': 'logging.FileHandler',
                 'filename': LOG_DIR / 'trace.log',
                 'formatter': 'trace',
             },
             'ecs_json': {
-                'level': 'DEBUG',
+                'level': '{{ log_level }}',
                 'class': 'logging.FileHandler',
                 'filename': LOG_DIR / 'ecs_json.log',
                 'formatter': "ecs_logging",
@@ -262,17 +262,15 @@ logging.config.dictConfig(
             '': {
                 'handlers': ['request_log', 'trace_log', 'ecs_json'],
                 'propagate': True,
-                'level': 'DEBUG',
+                'level': '{{ log_level }}',
             },
             # Increase logging level on loggers that are noisy at debug level
             # Note: django.server logs at warning level for 404s.
             'django.server': {
-                # 'level': 'DEBUG',
                 'level': 'ERROR',
                 'handlers': ['mail_admins']
             },
             'django.db': {
-                # 'level': 'DEBUG',
                 'level': 'ERROR',
                 'handlers': ['mail_admins']
             },


### PR DESCRIPTION
@datadavev @rushirajnenuji Hi Dave and Rushiraj,
The settings.py.j2 file is updated to use the newly defined "log_level" parameter. The default value for 'log_level' is "INFO" and the stage value is "DEBUG": 

ssm-param-get /uc3/ezid/ui/default/log_level
INFO

ssm-param-get /uc3/ezid/ui/stg/log_level
DEBUG

Please review and let me know if you have questions.

Thank you

Jing

 