### PR TITLE
pass profile through metadata['_p']

### DIFF
--- a/ezidapp/management/commands/proc-datacite.py
+++ b/ezidapp/management/commands/proc-datacite.py
@@ -61,7 +61,7 @@ class Command(ezidapp.management.commands.proc_base.AsyncProcessingCommand):
         #     ^---------
         doi: str = ref_id.identifier[4:]
         metadata = ref_id.metadata
-        metadata['_p'] = str(ref_id.profile)
+        metadata['_profile'] = str(ref_id.profile)
         datacenter = str(ref_id.datacenter)
         r = impl.datacite.uploadMetadata(doi, {}, metadata, True, datacenter)
         # r can be:

--- a/ezidapp/management/commands/proc-datacite.py
+++ b/ezidapp/management/commands/proc-datacite.py
@@ -61,6 +61,7 @@ class Command(ezidapp.management.commands.proc_base.AsyncProcessingCommand):
         #     ^---------
         doi: str = ref_id.identifier[4:]
         metadata = ref_id.metadata
+        metadata['_p'] = str(ref_id.profile)
         datacenter = str(ref_id.datacenter)
         r = impl.datacite.uploadMetadata(doi, {}, metadata, True, datacenter)
         # r can be:


### PR DESCRIPTION
@datadavev @rushirajnenuji Hi Dave and Rushiraj,
The `formRecord` function has two options to get the profile info:
1. through the "profile" parameter of the function
2. through the metadata["_p"] data field

Since the caller `uploadMetadata` does not use the profile parameter, option 2 should be considered.

This change still needs comprehensive tests to cover all datacite related profiles including:
* datacite
* dc
This change should not affect other profiles but tests are also needed.

Test data should cover both name:value and XML formats.

Please let me know if you have questions.

Thank you

Jing
