### PR TITLE
Bug fix to handle shoulder string with dot

### DIFF
--- a/ezidapp/management/commands/diag-create-missing-minters-tmp-fix.py
+++ b/ezidapp/management/commands/diag-create-missing-minters-tmp-fix.py
@@ -92,9 +92,8 @@ class Command(django.core.management.BaseCommand):
                 unspecified_count += 1
                 continue
 
-            naan_str, shoulder_str = re.split(r'[/:.]', s.minter)[-2:]
             # noinspection PyProtectedMember
-            bdb_path = impl.nog.bdb._get_bdb_path(naan_str, shoulder_str, root_path=None)
+            bdb_path = impl.nog.bdb.get_bdb_path_by_shoulder_model(s)
             if pathlib.Path(bdb_path).exists():
                 continue
 


### PR DESCRIPTION
@rushirajnenuji Hi Rushiraj,
While testing the create missing minters script on stage, I found additional issue:
current script failed on the following `shoulder.minter` which contains a dot in the  shoulder string 's6.caida':
- 'https://n2t.net/a/ezid/m/ark/d1986/s6.caida',
- 'https://n2t.net/a/ezid/m/ark/81986/s6.caida',

I changed the script to use this build-in function which is used by mint identifier API : - impl.nog.bdb.get_bdb_path_by_shoulder_model(shoulder_model) to handle this.

Please review and let me know if you have qeustions.

Thank you

Jing