### PR TITLE
Can we remove berkeley db from the dev requirements.txt ?

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,7 +10,7 @@ myloginpath~=0.0.2
 Jinja2~=3.0.1
 Pygments~=2.15.0
 boto3~=1.18.33
-bsddb3~=6.2.9
+
 fasteners~=0.16.3
 feedparser~=6.0.8
 filelock~=3.0.12


### PR DESCRIPTION
I believe this can be removed, right?  I thought Maria said that it was no longer necessary.

I'm still trying to get things set up so couldn't verify on my machin, but I assume one of you will know and can accept this PR if it's ok.  (Otherwise you can reject it.)