### PR TITLE
upgrade Jinja2 to 3.1.3

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,7 +7,7 @@ aiomysql~=0.0.21
 mysql~=0.0.3
 myloginpath~=0.0.2
 
-Jinja2~=3.0.1
+Jinja2~=3.1.3
 Pygments~=2.15.0
 boto3~=1.18.33
 bsddb3~=6.2.9

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ aiomysql~=0.0.21
 mysql~=0.0.3
 myloginpath~=0.0.2
 
-Jinja2~=3.0.1
+Jinja2~=3.1.3
 Pygments~=2.15.0
 boto3~=1.18.33
 bsddb3~=6.2.9


### PR DESCRIPTION
@sfisher @rushirajnenuji Hi Scott and Rushiraj,
This is to upgrade Jinja2 to 3.1.3. The ezid-stg is running on v3.2.4rc0 with this update. Please take a look and let me know if you have quesitons.

Thank you

Jing