### PR TITLE
468 python 311 upgrade

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.8'
+          python-version: '3.11'
           architecture: 'x64'
 
       - name: Start MySQL service

--- a/tests/test_api_util.py
+++ b/tests/test_api_util.py
@@ -13,7 +13,13 @@ def factory():
 @pytest.mark.parametrize("val,expected",[
     ('text/plain', True),
     ('text/plain; charset=utf-8', True),
+    ('text/plain; charset=UTF-8', True),
+    ('TEXT/PLAIN; charset=utf-8', False),
     ('text/plain; charset=US-ASCII', False),
+    ('; charset=utf-8', True),      # mimetype=''
+    ('; charset=US-ASCII', False),  # mimetype=''
+    ('charset=utf-8', False),
+    ('charset=US-ASCII', False),
     ('text/html', False),
     ('text/xml; charset=utf-8', False),
     ('application/json', False),

--- a/tests/test_api_util.py
+++ b/tests/test_api_util.py
@@ -1,0 +1,27 @@
+#  Copyright©2021, Regents of the University of California
+#  http://creativecommons.org/licenses/BSD
+
+import pytest
+
+from django.test import RequestFactory
+import impl.api as api
+
+@pytest.fixture
+def factory():
+    return RequestFactory()
+
+@pytest.mark.parametrize("val,expected",[
+    ('text/plain', True),
+    ('text/plain; charset=utf-8', True),
+    ('text/plain; charset=US-ASCII', False),
+    ('text/html', False),
+    ('text/xml; charset=utf-8', False),
+    ('application/json', False),
+    ('application/javascript', False),
+    ('application/x-www-form-urlencoded', False),
+])
+def test_content_type_1(factory, val, expected):
+    request = factory.post('/shoulder/ark:/99999/fk4', content_type=val)
+    ret = api.is_text_plain_utf8(request)
+    assert ret == expected
+        

--- a/tests/test_form_objects.py
+++ b/tests/test_form_objects.py
@@ -1,0 +1,55 @@
+import pytest
+import re
+
+import impl.form_objects as form_objects
+
+
+@pytest.mark.parametrize("string,expected",[
+    ('2000', '2000'),
+    ('200', None),
+    ('2', None),
+    ('x', None),
+    ('yyyy', None),
+    ('', None),
+    (':unac', ':unac'),
+    (':unal', ':unal'),
+    (':unap', ':unap'),
+    (':unas', ':unas'),
+    (':unav', ':unav'),
+    (':unkn', ':unkn'),
+    (':none', ':none'),
+    (':tba', ':tba'),
+    (':tba', ':tba'),
+    (':tba', ':tba'),
+])
+def test_regex_year(string, expected):
+    pattern = form_objects.REGEX_4DIGITYEAR
+    match = re.search(pattern, string)
+    if match:
+        assert match.group() == expected
+    
+# REGEX_GEOPOINT = '-?(\d+(\.\d*)?|\.\d+)$'
+@pytest.mark.parametrize("string,expected",[
+    ('-123.456', '-123.456'),
+    ('123.456', '123.456'),
+    ('1.', '1.'),
+    ('-1.', '-1.'),
+    ('12.', '12.'),
+    ('.1', '.1'),
+    ('-.1', '-.1'),
+    ('.456', '.456'),
+    ('-.456', '-.456'),
+    ('.', None),
+    ('x', None),
+    ('yyyy', None),
+    ('', None),
+])
+def test_regex_geopoint(string, expected):
+    pattern = form_objects.REGEX_GEOPOINT
+    match = re.search(pattern, string)
+    if match:
+        assert match.group() == expected
+
+
+
+


### PR DESCRIPTION
@sfisher Hi Scott,
This is to update the github action to use Python 3.11 for EZID unit and integration tests. 

A few unit tests are added for functions that use deprecated interfaces (reported by the Python interpreter with option -Wd). Fixes to these functions will be implemented in the near future.

Please review and let me know if you have questions.

Thank you

Jing 
