### PR TITLE
Updates the SearchIdentifier updateTime 

### DIFF
--- a/ezidapp/management/commands/proc-link-checker-update.py
+++ b/ezidapp/management/commands/proc-link-checker-update.py
@@ -97,21 +97,15 @@ class Command(ezidapp.management.commands.proc_base.AsyncProcessingCommand):
                                 si2 = ezidapp.models.identifier.SearchIdentifier.objects.get(
                                     identifier=si.identifier
                                 )
-                                # get before values for OpenSearchDoc for link/issues
-                                before_link_is_broken = si2.linkIsBroken
-                                before_has_issues = si2.hasIssues
-
                                 si2.linkIsBroken = newValue
                                 si2.computeHasIssues()
 
-                                # only update if the record is "dirty" and the values have changed
-                                if before_link_is_broken != si2.linkIsBroken or before_has_issues != si2.hasIssues:
-                                    si2.updateTime = int(time.time())
-                                    si2.save(update_fields=["updateTime", "linkIsBroken", "hasIssues"])
-                                    open_s = OpenSearchDoc(identifier=si2)
-                                    open_s.update_link_issues(link_is_broken=si2.linkIsBroken,
-                                                              has_issues=si2.hasIssues,
-                                                              update_time=si2.updateTime)
+                                si2.updateTime = int(time.time())
+                                si2.save(update_fields=["updateTime", "linkIsBroken", "hasIssues"])
+                                open_s = OpenSearchDoc(identifier=si2)
+                                open_s.update_link_issues(link_is_broken=si2.linkIsBroken,
+                                                          has_issues=si2.hasIssues,
+                                                          update_time=si2.updateTime)
                         except ezidapp.models.identifier.SearchIdentifier.DoesNotExist:
                             log.exception('SearchIdentifier.DoesNotExist')
                         except opensearchpy.exceptions.OpenSearchException as e:

--- a/ezidapp/management/commands/proc-link-checker-update.py
+++ b/ezidapp/management/commands/proc-link-checker-update.py
@@ -18,6 +18,7 @@ import ezidapp.models.link_checker
 import impl.log
 from impl.open_search_doc import OpenSearchDoc
 import opensearchpy.exceptions
+import time
 
 log = logging.getLogger(__name__)
 
@@ -96,11 +97,21 @@ class Command(ezidapp.management.commands.proc_base.AsyncProcessingCommand):
                                 si2 = ezidapp.models.identifier.SearchIdentifier.objects.get(
                                     identifier=si.identifier
                                 )
+                                # get before values for OpenSearchDoc for link/issues
+                                before_link_is_broken = si2.linkIsBroken
+                                before_has_issues = si2.hasIssues
+
                                 si2.linkIsBroken = newValue
                                 si2.computeHasIssues()
-                                si2.save(update_fields=["linkIsBroken", "hasIssues"])
-                                open_s = OpenSearchDoc(identifier=si2)
-                                open_s.update_link_issues(link_is_broken=si2.linkIsBroken, has_issues=si2.hasIssues)
+
+                                # only update if the record is "dirty" and the values have changed
+                                if before_link_is_broken != si2.linkIsBroken or before_has_issues != si2.hasIssues:
+                                    si2.updateTime = int(time.time())
+                                    si2.save(update_fields=["updateTime", "linkIsBroken", "hasIssues"])
+                                    open_s = OpenSearchDoc(identifier=si2)
+                                    open_s.update_link_issues(link_is_broken=si2.linkIsBroken,
+                                                              has_issues=si2.hasIssues,
+                                                              update_time=si2.updateTime)
                         except ezidapp.models.identifier.SearchIdentifier.DoesNotExist:
                             log.exception('SearchIdentifier.DoesNotExist')
                         except opensearchpy.exceptions.OpenSearchException as e:

--- a/impl/open_search_doc.py
+++ b/impl/open_search_doc.py
@@ -18,6 +18,7 @@ from opensearchpy import OpenSearch
 from opensearchpy.exceptions import NotFoundError
 from django.conf import settings
 import urllib
+import time
 
 # the functools allows memoizing the results of functions, so they're not recalculated every time (ie cached
 # results if called more than once on the same instance)
@@ -138,10 +139,11 @@ class OpenSearchDoc:
             return True
         return False
 
-    def update_link_issues(self, link_is_broken=False, has_issues=False):
+    # Note that this time is passed in as an integer, but it's converted to an iso datetime for opensearch
+    def update_link_issues(self, link_is_broken=False, has_issues=False, update_time=int(time.time())):
         dict_to_update = {
             'open_search_updated': datetime.datetime.now().isoformat(),
-            'update_time': datetime.datetime.now().isoformat(),
+            'update_time': datetime.datetime.utcfromtimestamp(update_time).isoformat(),
             'link_is_broken': link_is_broken,
             'has_issues': has_issues }
 

--- a/tests/test_open_search_doc.py
+++ b/tests/test_open_search_doc.py
@@ -272,7 +272,7 @@ def test_update_link_issues(mock_client, open_search_doc):
     mock_client.update.return_value = mock_response
 
     # Act
-    result = open_search_doc.update_link_issues(link_is_broken=True, has_issues=True)
+    result = open_search_doc.update_link_issues(link_is_broken=True, has_issues=True, update_time=1727984570)
 
     # Assert
     mock_client.update.assert_called_once_with(
@@ -282,7 +282,8 @@ def test_update_link_issues(mock_client, open_search_doc):
             'open_search_updated': ANY,  # Use unittest.mock.ANY if the exact value doesn't matter
             'update_time': ANY,
             'link_is_broken': True,
-            'has_issues': True
+            'has_issues': True,
+            'update_time': '2024-10-03T19:42:50'
         }}
     )
     assert result is True


### PR DESCRIPTION
(and OpenSearch update_time) from link checker.

1) only updates the db/opensearch if values are changed
2) now OpenSearch link checker update takes the unix time in function signature
3) updated tests to be correct for changed method in opensearch doc class

closes https://github.com/CDLUC3/ezid/issues/752 