### PR TITLE
774 fix contact form email issue

### DIFF
--- a/ezidapp/management/commands/proc-cleanup-async-queues_v2.py
+++ b/ezidapp/management/commands/proc-cleanup-async-queues_v2.py
@@ -126,6 +126,7 @@ class Command(ezidapp.management.commands.proc_base.AsyncProcessingCommand):
 
             # iterate over query set to check each identifier status
             for refId in refIdsQS:
+                last_id = refId.pk
 
                 # set status for each handle system
                 identifierStatus = {
@@ -167,7 +168,6 @@ class Command(ezidapp.management.commands.proc_base.AsyncProcessingCommand):
                         "Delete identifier: " + refId.identifier + " from refIdentifier table.")
                     self.deleteRecord(self.refIdentifier, refId.pk, record_type='refId', identifier=refId.identifier)
 
-            last_id = refId.pk
             if len(refIdsQS) < BATCH_SIZE:
                 if updated_from is not None or updated_to is not None:
                     log.info(f"Finished - Checking ref Ids: {time_range_str}")

--- a/impl/ui.py
+++ b/impl/ui.py
@@ -10,7 +10,7 @@ import urllib.response
 
 import django.conf
 import django.contrib.messages
-import django.core.mail
+from django.core.mail import EmailMessage
 import django.http
 import django.template
 import django.template.loader
@@ -90,7 +90,14 @@ def contact(request):
                 else:
                     message += "Newsletter option NOT checked."
             try:
-                django.core.mail.send_mail(title, message, P['email'], emails)
+                email = EmailMessage(
+                    subject=title,
+                    body=message,
+                    from_email=django.conf.settings.SERVER_EMAIL,
+                    to=emails,
+                    reply_to=P['email'],
+                )
+                email.send(fail_silently=False)
                 # 'extra_tags' used for recording a Google Analytics event
                 django.contrib.messages.add_message(
                     request,

--- a/impl/ui.py
+++ b/impl/ui.py
@@ -95,7 +95,7 @@ def contact(request):
                     body=message,
                     from_email=django.conf.settings.SERVER_EMAIL,
                     to=emails,
-                    reply_to=P['email'],
+                    reply_to=[P['email']],
                 )
                 email.send(fail_silently=False)
                 # 'extra_tags' used for recording a Google Analytics event


### PR DESCRIPTION
@sfisher Hi Scott,
Here are the changes:
* replace the wrapper function `django.core.mail.send_mail()` which does not support `reply_to` with the lower level class EmailMessage. We need the the `reply_to` field to store user entered email which will be used to generate help desk email
* bug fix to the `proc-cleanup-async-queues_v2.py` script - the `last_id = refId.pk` statement should be inside the loop otherwise "None" error will be generated when query returns no results.

Please review and let me know if you have questions.

Thank you

Jing 