### PR TITLE
Change regular expression to allow both upper and lower case letters in language code

### DIFF
--- a/impl/form_objects.py
+++ b/impl/form_objects.py
@@ -76,7 +76,7 @@ REGEX_4DIGITYEAR = r'^(\d{4}|\(:unac\)|\(:unal\)|\(:unap\)|\(:unas\)|\(:unav\)|\
    \(:unkn\)|\(:none\)|\(:null\)|\(:tba\)|\(:etal\)|\(:at\))$'
 REGEX_GEOPOINT = r'-?(\d+(\.\d*)?|\.\d+)$'
 # http://stackoverflow.com/questions/3962543/how-can-i-validate-a-culture-code-with-a-regular-expression
-REGEX_LANGUAGE = '^[a-z]{2,3}(?:-[A-Z]{2,3}(?:-[a-zA-Z]{4})?)?$'
+REGEX_LANGUAGE = '^[a-z]{2,3}(?:-[a-zA-Z]{2,3}(?:-[a-zA-Z]{4})?)?$'
 ERR_4DIGITYEAR = _("Four digits required")
 ERR_DATE = _("Please use format YYYY-MM-DD.")
 ERR_CREATOR = _("Please fill in a value for creator.")


### PR DESCRIPTION
After the dash like `en-US` it used to only allow upper case letters.

This could be either.

I looked at the DataCite docs and it mentions [IETF BCP 47](https://en.wikipedia.org/wiki/IETF_language_tag), [ISO 639-1 language codes](https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes).  I looked over these codes and it appears that this regex will cover it (I don't see any non-alphabetic characters in either part).

It looks like the error message is ok: `ERR_LANGUAGE = _("Must be a valid language code (IETF BCP 47 or ISO 639-1)")`

I didn't see it come up in the documentation elsewhere when I searched.