### PR TITLE
Addresses #823, #824 -- navigation menus and aria hidden

### DIFF
--- a/dev/includes/header.html
+++ b/dev/includes/header.html
@@ -18,7 +18,7 @@
     <img src="images/mobile-menu.svg" alt="Show or hide navigation" class="header__nav-button-icon">
   </button>
 
-  <nav role="navigation" id="js-header__nav" class="header__nav--selected" aria-hidden="false">
+  <nav role="navigation" id="js-header__nav" class="header__nav--selected">
     <a class="header__nav-item-search" href="">Search</a>
     <details aria-expanded="false">
       <summary class="header__nav-item-learn" role="button">Learn</summary>

--- a/dev/includes/login-modal.html
+++ b/dev/includes/login-modal.html
@@ -2,7 +2,9 @@
 <div id="js-login-modal" class="login-modal" aria-expanded="false" role="dialog" aria-labelledby="login-modal__title">
 	<div class="login-modal__header">
 		<div id="login-modal__title" class="login-modal__title">Access your account</div>
-		<img id="js-login-modal__close" src="images/icon_cross.svg" alt="close" class="login-modal__close">
+		<button type="button" id="js-login-modal__close" class="login-modal__close" aria-label="Close modal">
+  		<img src="images/icon_cross.svg" alt="close">
+		</button>
 	</div>
 	<form id="js-login-modal__form" action="url-here" class="login-modal__form">
     <div class="login-modal__form-element fcontrol__group-stacked">

--- a/dev/includes/login-modal.html
+++ b/dev/includes/login-modal.html
@@ -1,5 +1,5 @@
 
-<div id="js-login-modal" class="login-modal" aria-hidden="true" role="dialog" aria-labelledby="login-modal__title">
+<div id="js-login-modal" class="login-modal" aria-expanded="false" role="dialog" aria-labelledby="login-modal__title">
 	<div class="login-modal__header">
 		<div id="login-modal__title" class="login-modal__title">Access your account</div>
 		<img id="js-login-modal__close" src="images/icon_cross.svg" alt="close" class="login-modal__close">

--- a/dev/js/main2.js
+++ b/dev/js/main2.js
@@ -61,8 +61,9 @@ $(document).ready(function () {
 
   // ***** Modal Login ***** //
 
-  // Toggle open and closed from login button
 
+/*
+  // Toggle open and closed from login button
   $('#js-header__loginout-button').click(function () {
     if ($('#js-login-modal').attr('aria-expanded') == 'false') {
       $('#js-login-modal').attr('aria-expanded', 'true');
@@ -74,7 +75,8 @@ $(document).ready(function () {
 
   // Close when close icon is clicked
 
-  $('#js-login-modal__close').click(function () {
+  $('#js-login-modal__close').click(function (e) {
+    e.preventDefault();
     $('#js-login-modal').attr('aria-expanded', 'false');
     $('#js-login-modal').fadeToggle(200);
   });
@@ -85,6 +87,7 @@ $(document).ready(function () {
     $('#js-login-modal').attr('aria-expanded', 'false');
     $('#js-login-modal').fadeToggle(200);
   });
+*/
 
 }); // Close $(document).ready(function()
 
@@ -141,5 +144,73 @@ document.addEventListener('DOMContentLoaded', () => {
   function closeMenu() {
     detailsElement.removeAttribute('open');
     detailsElement.setAttribute('aria-expanded', 'false');
+  }
+});
+
+
+
+// ***** Modal Login ***** //
+document.addEventListener('DOMContentLoaded', () => {
+  const modal = document.getElementById('js-login-modal');
+  const closeButton = document.getElementById('js-login-modal__close');
+  const formElements = modal.querySelectorAll('input, button, a');
+  const firstFocusable = formElements[0];
+  const lastFocusable = formElements[formElements.length - 1];
+
+  const openModal = () => {
+    modal.setAttribute('aria-expanded', 'true');
+    modal.style.display = 'block';
+    // modal.classList.add('open');
+    firstFocusable.focus();
+  };
+
+  const closeModal = (event) => {
+    console.log("Closing modal");
+    if (event) {
+      event.preventDefault();
+    }
+    modal.setAttribute('aria-expanded', 'false');
+    modal.style.display = 'none';
+    // modal.classList.remove('open');
+  };
+
+  const handleKeydown = (event) => {
+    if (event.key === 'Escape') {
+      closeModal();
+    }
+
+    if (event.key === 'Tab') {
+      // Manage focus trapping
+      if (event.shiftKey) {
+        // Shift + Tab: focus backwards
+        if (document.activeElement === firstFocusable) {
+          event.preventDefault();
+          lastFocusable.focus();
+        }
+      } else {
+        // Tab: focus forwards
+        if (document.activeElement === lastFocusable) {
+          event.preventDefault();
+          firstFocusable.focus();
+        }
+      }
+    }
+  };
+
+  // Add event listeners
+  closeButton.addEventListener('click', closeModal);
+  document.addEventListener('keydown', handleKeydown);
+
+  const openButton = document.getElementById('js-header__loginout-button');
+  if (openButton) {
+    openButton.addEventListener('click', () => {
+      const expanded = modal.getAttribute('aria-expanded');
+      if (expanded === null || expanded === 'false') {
+        console.log("Opening modal");
+        openModal();
+      } else {
+        closeModal();
+      }
+    });
   }
 });

--- a/dev/js/main2.js
+++ b/dev/js/main2.js
@@ -64,10 +64,10 @@ $(document).ready(function () {
   // Toggle open and closed from login button
 
   $('#js-header__loginout-button').click(function () {
-    if ($('#js-login-modal').attr('aria-hidden') == 'true') {
-      $('#js-login-modal').attr('aria-hidden', 'false');
+    if ($('#js-login-modal').attr('aria-expanded') == 'false') {
+      $('#js-login-modal').attr('aria-expanded', 'true');
     } else {
-      $('#js-login-modal').attr('aria-hidden', 'true');
+      $('#js-login-modal').attr('aria-expanded', 'false');
     }
     $('#js-login-modal').fadeToggle(200);
   });
@@ -75,14 +75,14 @@ $(document).ready(function () {
   // Close when close icon is clicked
 
   $('#js-login-modal__close').click(function () {
-    $('#js-login-modal').attr('aria-hidden', 'true');
+    $('#js-login-modal').attr('aria-expanded', 'false');
     $('#js-login-modal').fadeToggle(200);
   });
 
   // Close when form is submitted
 
   $('#js-login-modal__form').submit(function () {
-    $('#js-login-modal').attr('aria-hidden', 'true');
+    $('#js-login-modal').attr('aria-expanded', 'false');
     $('#js-login-modal').fadeToggle(200);
   });
 

--- a/dev/js/main2.js
+++ b/dev/js/main2.js
@@ -1,7 +1,7 @@
 // ##### Main JavaScript ##### //
 
-$(document).ready(function(){
-  
+$(document).ready(function () {
+
   // ***** Show/hide mobile menu via mobile menu icon ***** //
 
   // Before toggling menu, change default header menu class to non-selected state and change default aria attribute:
@@ -12,11 +12,11 @@ $(document).ready(function(){
   $('#js-header__nav').attr('aria-expanded', 'false');
 
   // Toggle classes and attributes:
-  $('#js-header__nav-button').click(function(){
-    
+  $('#js-header__nav-button').click(function () {
+
     $('#js-header__nav').toggleClass('header__nav header__nav--selected', 300, 'easeInOutCubic');
 
-    if($('#js-header__nav').attr('aria-expanded') == 'false') {
+    if ($('#js-header__nav').attr('aria-expanded') == 'false') {
       $('#js-header__nav').attr('aria-expanded', 'true');
     } else {
       $('#js-header__nav').attr('aria-expanded', 'false');
@@ -28,11 +28,11 @@ $(document).ready(function(){
 
   // Pre-open an accordion section by retrieving the referring URL hash (up to 2 digits), removing the hash tag, and adding the hash value to the jQuery selector:
 
-  var urlhash = window.location.hash.substr(1,3);
-  
-  $('#accordion__section-'+urlhash).attr('open', '');
+  var urlhash = window.location.hash.substr(1, 3);
 
-  $('.accordion__title').click(function(){
+  $('#accordion__section-' + urlhash).attr('open', '');
+
+  $('.accordion__title').click(function () {
 
     // If an accordion title is clicked, close all the other sections if they are open and set their aria-expanded attributes to false:
     if ($(this).parent().siblings().attr('open', '')) {
@@ -51,11 +51,11 @@ $(document).ready(function(){
 
   // If 'required' attribute exists on a text input, add 'required' class to its label:
 
-  $('.fcontrol__text-field-stacked[required]').map(function() {
+  $('.fcontrol__text-field-stacked[required]').map(function () {
     $(this).siblings('.fcontrol__text-label-stacked').addClass('fcontrol__label-required');
   });
 
-  $('.fcontrol__text-field-inline[required]').map(function() {
+  $('.fcontrol__text-field-inline[required]').map(function () {
     $(this).siblings('.fcontrol__text-label-inline').addClass('fcontrol__label-required');
   });
 
@@ -63,10 +63,10 @@ $(document).ready(function(){
 
   // Toggle open and closed from login button
 
-  $('#js-header__loginout-button').click(function(){
+  $('#js-header__loginout-button').click(function () {
     if ($('#js-login-modal').attr('aria-hidden') == 'true') {
       $('#js-login-modal').attr('aria-hidden', 'false');
-    }else {
+    } else {
       $('#js-login-modal').attr('aria-hidden', 'true');
     }
     $('#js-login-modal').fadeToggle(200);
@@ -74,16 +74,69 @@ $(document).ready(function(){
 
   // Close when close icon is clicked
 
-  $('#js-login-modal__close').click(function(){
+  $('#js-login-modal__close').click(function () {
     $('#js-login-modal').attr('aria-hidden', 'true');
     $('#js-login-modal').fadeToggle(200);
   });
 
   // Close when form is submitted
 
-  $('#js-login-modal__form').submit(function(){
+  $('#js-login-modal__form').submit(function () {
     $('#js-login-modal').attr('aria-hidden', 'true');
     $('#js-login-modal').fadeToggle(200);
   });
 
 }); // Close $(document).ready(function()
+
+// ***** The "Learn" menu needs more flexibility for keyboard navigation ***** //
+
+document.addEventListener('DOMContentLoaded', () => {
+  const detailsElement = document.getElementById('header__nav-details-learn');
+  const summaryElement = detailsElement.querySelector('summary');
+
+  // Close menu when clicking outside
+  document.addEventListener('click', (event) => {
+    if (!detailsElement.contains(event.target)) {
+      detailsElement.removeAttribute('open');
+      detailsElement.setAttribute('aria-expanded', 'false');
+    }
+  });
+
+  // Toggle aria-expanded when menu is toggled
+  summaryElement.addEventListener('click', () => {
+    const isOpen = detailsElement.hasAttribute('open');
+    detailsElement.setAttribute('aria-expanded', String(!isOpen));
+  });
+
+  // Keyboard navigation
+  detailsElement.addEventListener('keydown', (event) => {
+    if (event.key === 'Escape') {
+      detailsElement.removeAttribute('open');
+      detailsElement.setAttribute('aria-expanded', 'false');
+      summaryElement.focus();
+    }
+  });
+
+  // Manage focus within menu
+  const focusableElements = detailsElement.querySelectorAll('a');
+  detailsElement.addEventListener('keydown', (event) => {
+    const focusArray = Array.from(focusableElements);
+    const currentIndex = focusArray.indexOf(document.activeElement);
+
+    if (event.key === 'Tab') {
+      if (event.shiftKey) {
+        // Tab backwards
+        if (currentIndex === 0 || currentIndex === -1) {
+          event.preventDefault();
+          focusArray[focusArray.length - 1].focus();
+        }
+      } else {
+        // Tab forwards
+        if (currentIndex === focusArray.length - 1) {
+          event.preventDefault();
+          focusArray[0].focus();
+        }
+      }
+    }
+  });
+});

--- a/dev/js/main2.js
+++ b/dev/js/main2.js
@@ -93,12 +93,12 @@ $(document).ready(function () {
 document.addEventListener('DOMContentLoaded', () => {
   const detailsElement = document.getElementById('header__nav-details-learn');
   const summaryElement = detailsElement.querySelector('summary');
+  const focusableElements = detailsElement.querySelectorAll('a');
 
   // Close menu when clicking outside
   document.addEventListener('click', (event) => {
     if (!detailsElement.contains(event.target)) {
-      detailsElement.removeAttribute('open');
-      detailsElement.setAttribute('aria-expanded', 'false');
+      closeMenu();
     }
   });
 
@@ -108,35 +108,38 @@ document.addEventListener('DOMContentLoaded', () => {
     detailsElement.setAttribute('aria-expanded', String(!isOpen));
   });
 
+  // Close menu when tabbing out
+  detailsElement.addEventListener('keydown', (event) => {
+    if (event.key === 'Tab') {
+      const focusArray = Array.from(focusableElements);
+      const firstElement = focusArray[0];
+      const lastElement = focusArray[focusArray.length - 1];
+
+      if (event.shiftKey && document.activeElement === firstElement) {
+        // Shift + Tab on the first element
+        event.preventDefault();
+        closeMenu();
+        summaryElement.focus();
+      } else if (!event.shiftKey && document.activeElement === lastElement) {
+        // Tab on the last element
+        event.preventDefault();
+        closeMenu();
+        summaryElement.focus();
+      }
+    }
+  });
+
   // Keyboard navigation
   detailsElement.addEventListener('keydown', (event) => {
     if (event.key === 'Escape') {
-      detailsElement.removeAttribute('open');
-      detailsElement.setAttribute('aria-expanded', 'false');
+      closeMenu();
       summaryElement.focus();
     }
   });
 
-  // Manage focus within menu
-  const focusableElements = detailsElement.querySelectorAll('a');
-  detailsElement.addEventListener('keydown', (event) => {
-    const focusArray = Array.from(focusableElements);
-    const currentIndex = focusArray.indexOf(document.activeElement);
-
-    if (event.key === 'Tab') {
-      if (event.shiftKey) {
-        // Tab backwards
-        if (currentIndex === 0 || currentIndex === -1) {
-          event.preventDefault();
-          focusArray[focusArray.length - 1].focus();
-        }
-      } else {
-        // Tab forwards
-        if (currentIndex === focusArray.length - 1) {
-          event.preventDefault();
-          focusArray[0].focus();
-        }
-      }
-    }
-  });
+  // Helper function to close the menu
+  function closeMenu() {
+    detailsElement.removeAttribute('open');
+    detailsElement.setAttribute('aria-expanded', 'false');
+  }
 });

--- a/dev/js/main2.js
+++ b/dev/js/main2.js
@@ -59,36 +59,6 @@ $(document).ready(function () {
     $(this).siblings('.fcontrol__text-label-inline').addClass('fcontrol__label-required');
   });
 
-  // ***** Modal Login ***** //
-
-
-/*
-  // Toggle open and closed from login button
-  $('#js-header__loginout-button').click(function () {
-    if ($('#js-login-modal').attr('aria-expanded') == 'false') {
-      $('#js-login-modal').attr('aria-expanded', 'true');
-    } else {
-      $('#js-login-modal').attr('aria-expanded', 'false');
-    }
-    $('#js-login-modal').fadeToggle(200);
-  });
-
-  // Close when close icon is clicked
-
-  $('#js-login-modal__close').click(function (e) {
-    e.preventDefault();
-    $('#js-login-modal').attr('aria-expanded', 'false');
-    $('#js-login-modal').fadeToggle(200);
-  });
-
-  // Close when form is submitted
-
-  $('#js-login-modal__form').submit(function () {
-    $('#js-login-modal').attr('aria-expanded', 'false');
-    $('#js-login-modal').fadeToggle(200);
-  });
-*/
-
 }); // Close $(document).ready(function()
 
 // ***** The "Learn" menu needs more flexibility for keyboard navigation ***** //
@@ -148,14 +118,18 @@ document.addEventListener('DOMContentLoaded', () => {
 });
 
 
-
 // ***** Modal Login ***** //
 document.addEventListener('DOMContentLoaded', () => {
   const modal = document.getElementById('js-login-modal');
-  const closeButton = document.getElementById('js-login-modal__close');
+  const closeButton = document.getElementById('js-login-modal__close').parentElement;
   const formElements = modal.querySelectorAll('input, button, a');
   const firstFocusable = formElements[0];
   const lastFocusable = formElements[formElements.length - 1];
+  const openButton = document.getElementById('js-header__loginout-button');
+
+  // Ensure aria-expanded is set to false initially
+  modal.setAttribute('aria-expanded', 'false');
+  modal.style.display = 'none';
 
   const openModal = () => {
     modal.setAttribute('aria-expanded', 'true');
@@ -165,13 +139,13 @@ document.addEventListener('DOMContentLoaded', () => {
   };
 
   const closeModal = (event) => {
-    console.log("Closing modal");
     if (event) {
       event.preventDefault();
     }
     modal.setAttribute('aria-expanded', 'false');
     modal.style.display = 'none';
     // modal.classList.remove('open');
+    openButton.focus();
   };
 
   const handleKeydown = (event) => {
@@ -180,33 +154,44 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     if (event.key === 'Tab') {
-      // Manage focus trapping
+      // Allow tabbing outside and close modal if tabbing out
       if (event.shiftKey) {
         // Shift + Tab: focus backwards
         if (document.activeElement === firstFocusable) {
-          event.preventDefault();
-          lastFocusable.focus();
+          closeModal();
         }
       } else {
         // Tab: focus forwards
         if (document.activeElement === lastFocusable) {
-          event.preventDefault();
-          firstFocusable.focus();
+          closeModal();
         }
       }
     }
   };
 
   // Add event listeners
+  // Close modal when clicking outside
+  document.addEventListener('click', (event) => {
+    if (!modal.contains(event.target) && event.target !== openButton &&
+        modal.getAttribute('aria-expanded') === 'true') {
+      closeModal();
+    }
+  });
+
   closeButton.addEventListener('click', closeModal);
+  closeButton.addEventListener('keydown', (event) => {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      closeModal(event);
+    }
+  });
   document.addEventListener('keydown', handleKeydown);
 
-  const openButton = document.getElementById('js-header__loginout-button');
+
   if (openButton) {
     openButton.addEventListener('click', () => {
       const expanded = modal.getAttribute('aria-expanded');
       if (expanded === null || expanded === 'false') {
-        console.log("Opening modal");
         openModal();
       } else {
         closeModal();
@@ -214,3 +199,4 @@ document.addEventListener('DOMContentLoaded', () => {
     });
   }
 });
+

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -31,7 +31,7 @@ var ghPages = require('gulp-gh-pages');
 exports.default = parallel(scss, start, watcher);
 
 // exports.build = series(clean, fonts, scsslint_legacy, scsslint, jslint, scss_legacy, scss, assemble, minifyCss, copyimages, fonts);
-exports.build = series(clean, fonts, jslint, scss_legacy, scss, assemble, minifyCss, copyimages, fonts, copyCSS);
+exports.build = series(clean, fonts, jslint, scss_legacy, scss, assemble, minifyCss, copyimages, fonts, copyCSS, copyJS);
 
 exports.upload = githubpages;
 
@@ -128,6 +128,13 @@ function copyimages(cb) {
 function copyCSS(cb) {
   return src('ui_library/css/main2.min.css')
     .pipe(dest('static_src/stylesheets'));
+  cb();
+}
+
+// Copy the minified js to the place it actually needs to go in order to function
+function copyJS(cb) {
+  return src('ui_library/js/main2.min.js')
+    .pipe(dest('static_src/javascripts'));
   cb();
 }
 

--- a/static_src/javascripts/main2.min.js
+++ b/static_src/javascripts/main2.min.js
@@ -30850,24 +30850,26 @@ Detects support for the Flexible Box Layout model, a.k.a. Flexbox, which allows 
 })(window, document);
 // ##### Main JavaScript ##### //
 
-$(document).ready(function(){
-  
+$(document).ready(function () {
+
   // ***** Show/hide mobile menu via mobile menu icon ***** //
 
   // Before toggling menu, change default header menu class to non-selected state and change default aria attribute:
 
+  // According to ChatGPT using aria-hidden for visual appearance isn't recommended and items should not be hidden from
+  // screen readers. Instead, use aria-expanded to indicate the state of the menu.
   $('#js-header__nav').attr('class', 'header__nav');
-  $('#js-header__nav').attr('aria-hidden', 'true');
+  $('#js-header__nav').attr('aria-expanded', 'false');
 
   // Toggle classes and attributes:
-  $('#js-header__nav-button').click(function(){
-    
+  $('#js-header__nav-button').click(function () {
+
     $('#js-header__nav').toggleClass('header__nav header__nav--selected', 300, 'easeInOutCubic');
 
-    if($('#js-header__nav').attr('aria-hidden') == 'true') {
-      $('#js-header__nav').attr('aria-hidden', 'false');
+    if ($('#js-header__nav').attr('aria-expanded') == 'false') {
+      $('#js-header__nav').attr('aria-expanded', 'true');
     } else {
-      $('#js-header__nav').attr('aria-hidden', 'true');
+      $('#js-header__nav').attr('aria-expanded', 'false');
     }
 
   });
@@ -30876,11 +30878,11 @@ $(document).ready(function(){
 
   // Pre-open an accordion section by retrieving the referring URL hash (up to 2 digits), removing the hash tag, and adding the hash value to the jQuery selector:
 
-  var urlhash = window.location.hash.substr(1,3);
-  
-  $('#accordion__section-'+urlhash).attr('open', '');
+  var urlhash = window.location.hash.substr(1, 3);
 
-  $('.accordion__title').click(function(){
+  $('#accordion__section-' + urlhash).attr('open', '');
+
+  $('.accordion__title').click(function () {
 
     // If an accordion title is clicked, close all the other sections if they are open and set their aria-expanded attributes to false:
     if ($(this).parent().siblings().attr('open', '')) {
@@ -30899,11 +30901,11 @@ $(document).ready(function(){
 
   // If 'required' attribute exists on a text input, add 'required' class to its label:
 
-  $('.fcontrol__text-field-stacked[required]').map(function() {
+  $('.fcontrol__text-field-stacked[required]').map(function () {
     $(this).siblings('.fcontrol__text-label-stacked').addClass('fcontrol__label-required');
   });
 
-  $('.fcontrol__text-field-inline[required]').map(function() {
+  $('.fcontrol__text-field-inline[required]').map(function () {
     $(this).siblings('.fcontrol__text-label-inline').addClass('fcontrol__label-required');
   });
 
@@ -30911,20 +30913,83 @@ $(document).ready(function(){
 
   // Toggle open and closed from login button
 
-  $('#js-header__loginout-button').click(function(){
+  $('#js-header__loginout-button').click(function () {
+    if ($('#js-login-modal').attr('aria-hidden') == 'true') {
+      $('#js-login-modal').attr('aria-hidden', 'false');
+    } else {
+      $('#js-login-modal').attr('aria-hidden', 'true');
+    }
     $('#js-login-modal').fadeToggle(200);
   });
 
   // Close when close icon is clicked
 
-  $('#js-login-modal__close').click(function(){
+  $('#js-login-modal__close').click(function () {
+    $('#js-login-modal').attr('aria-hidden', 'true');
     $('#js-login-modal').fadeToggle(200);
   });
 
   // Close when form is submitted
 
-  $('#js-login-modal__form').submit(function(){
+  $('#js-login-modal__form').submit(function () {
+    $('#js-login-modal').attr('aria-hidden', 'true');
     $('#js-login-modal').fadeToggle(200);
   });
 
 }); // Close $(document).ready(function()
+
+// ***** The "Learn" menu needs more flexibility for keyboard navigation ***** //
+
+document.addEventListener('DOMContentLoaded', () => {
+  const detailsElement = document.getElementById('header__nav-details-learn');
+  const summaryElement = detailsElement.querySelector('summary');
+  const focusableElements = detailsElement.querySelectorAll('a');
+
+  // Close menu when clicking outside
+  document.addEventListener('click', (event) => {
+    if (!detailsElement.contains(event.target)) {
+      closeMenu();
+    }
+  });
+
+  // Toggle aria-expanded when menu is toggled
+  summaryElement.addEventListener('click', () => {
+    const isOpen = detailsElement.hasAttribute('open');
+    detailsElement.setAttribute('aria-expanded', String(!isOpen));
+  });
+
+  // Close menu when tabbing out
+  detailsElement.addEventListener('keydown', (event) => {
+    if (event.key === 'Tab') {
+      const focusArray = Array.from(focusableElements);
+      const firstElement = focusArray[0];
+      const lastElement = focusArray[focusArray.length - 1];
+
+      if (event.shiftKey && document.activeElement === firstElement) {
+        // Shift + Tab on the first element
+        event.preventDefault();
+        closeMenu();
+        summaryElement.focus();
+      } else if (!event.shiftKey && document.activeElement === lastElement) {
+        // Tab on the last element
+        event.preventDefault();
+        closeMenu();
+        summaryElement.focus();
+      }
+    }
+  });
+
+  // Keyboard navigation
+  detailsElement.addEventListener('keydown', (event) => {
+    if (event.key === 'Escape') {
+      closeMenu();
+      summaryElement.focus();
+    }
+  });
+
+  // Helper function to close the menu
+  function closeMenu() {
+    detailsElement.removeAttribute('open');
+    detailsElement.setAttribute('aria-expanded', 'false');
+  }
+});

--- a/static_src/javascripts/main2.min.js
+++ b/static_src/javascripts/main2.min.js
@@ -30911,8 +30911,9 @@ $(document).ready(function () {
 
   // ***** Modal Login ***** //
 
-  // Toggle open and closed from login button
 
+/*
+  // Toggle open and closed from login button
   $('#js-header__loginout-button').click(function () {
     if ($('#js-login-modal').attr('aria-expanded') == 'false') {
       $('#js-login-modal').attr('aria-expanded', 'true');
@@ -30924,7 +30925,8 @@ $(document).ready(function () {
 
   // Close when close icon is clicked
 
-  $('#js-login-modal__close').click(function () {
+  $('#js-login-modal__close').click(function (e) {
+    e.preventDefault();
     $('#js-login-modal').attr('aria-expanded', 'false');
     $('#js-login-modal').fadeToggle(200);
   });
@@ -30935,6 +30937,7 @@ $(document).ready(function () {
     $('#js-login-modal').attr('aria-expanded', 'false');
     $('#js-login-modal').fadeToggle(200);
   });
+*/
 
 }); // Close $(document).ready(function()
 
@@ -30991,5 +30994,73 @@ document.addEventListener('DOMContentLoaded', () => {
   function closeMenu() {
     detailsElement.removeAttribute('open');
     detailsElement.setAttribute('aria-expanded', 'false');
+  }
+});
+
+
+
+// ***** Modal Login ***** //
+document.addEventListener('DOMContentLoaded', () => {
+  const modal = document.getElementById('js-login-modal');
+  const closeButton = document.getElementById('js-login-modal__close');
+  const formElements = modal.querySelectorAll('input, button, a');
+  const firstFocusable = formElements[0];
+  const lastFocusable = formElements[formElements.length - 1];
+
+  const openModal = () => {
+    modal.setAttribute('aria-expanded', 'true');
+    modal.style.display = 'block';
+    // modal.classList.add('open');
+    firstFocusable.focus();
+  };
+
+  const closeModal = (event) => {
+    console.log("Closing modal");
+    if (event) {
+      event.preventDefault();
+    }
+    modal.setAttribute('aria-expanded', 'false');
+    modal.style.display = 'none';
+    // modal.classList.remove('open');
+  };
+
+  const handleKeydown = (event) => {
+    if (event.key === 'Escape') {
+      closeModal();
+    }
+
+    if (event.key === 'Tab') {
+      // Manage focus trapping
+      if (event.shiftKey) {
+        // Shift + Tab: focus backwards
+        if (document.activeElement === firstFocusable) {
+          event.preventDefault();
+          lastFocusable.focus();
+        }
+      } else {
+        // Tab: focus forwards
+        if (document.activeElement === lastFocusable) {
+          event.preventDefault();
+          firstFocusable.focus();
+        }
+      }
+    }
+  };
+
+  // Add event listeners
+  closeButton.addEventListener('click', closeModal);
+  document.addEventListener('keydown', handleKeydown);
+
+  const openButton = document.getElementById('js-header__loginout-button');
+  if (openButton) {
+    openButton.addEventListener('click', () => {
+      const expanded = modal.getAttribute('aria-expanded');
+      if (expanded === null || expanded === 'false') {
+        console.log("Opening modal");
+        openModal();
+      } else {
+        closeModal();
+      }
+    });
   }
 });

--- a/static_src/javascripts/main2.min.js
+++ b/static_src/javascripts/main2.min.js
@@ -30914,10 +30914,10 @@ $(document).ready(function () {
   // Toggle open and closed from login button
 
   $('#js-header__loginout-button').click(function () {
-    if ($('#js-login-modal').attr('aria-hidden') == 'true') {
-      $('#js-login-modal').attr('aria-hidden', 'false');
+    if ($('#js-login-modal').attr('aria-expanded') == 'false') {
+      $('#js-login-modal').attr('aria-expanded', 'true');
     } else {
-      $('#js-login-modal').attr('aria-hidden', 'true');
+      $('#js-login-modal').attr('aria-expanded', 'false');
     }
     $('#js-login-modal').fadeToggle(200);
   });
@@ -30925,14 +30925,14 @@ $(document).ready(function () {
   // Close when close icon is clicked
 
   $('#js-login-modal__close').click(function () {
-    $('#js-login-modal').attr('aria-hidden', 'true');
+    $('#js-login-modal').attr('aria-expanded', 'false');
     $('#js-login-modal').fadeToggle(200);
   });
 
   // Close when form is submitted
 
   $('#js-login-modal__form').submit(function () {
-    $('#js-login-modal').attr('aria-hidden', 'true');
+    $('#js-login-modal').attr('aria-expanded', 'false');
     $('#js-login-modal').fadeToggle(200);
   });
 

--- a/static_src/javascripts/main2.min.js
+++ b/static_src/javascripts/main2.min.js
@@ -30912,32 +30912,32 @@ $(document).ready(function () {
   // ***** Modal Login ***** //
 
 
-/*
-  // Toggle open and closed from login button
-  $('#js-header__loginout-button').click(function () {
-    if ($('#js-login-modal').attr('aria-expanded') == 'false') {
-      $('#js-login-modal').attr('aria-expanded', 'true');
-    } else {
+  /*
+    // Toggle open and closed from login button
+    $('#js-header__loginout-button').click(function () {
+      if ($('#js-login-modal').attr('aria-expanded') == 'false') {
+        $('#js-login-modal').attr('aria-expanded', 'true');
+      } else {
+        $('#js-login-modal').attr('aria-expanded', 'false');
+      }
+      $('#js-login-modal').fadeToggle(200);
+    });
+
+    // Close when close icon is clicked
+
+    $('#js-login-modal__close').click(function (e) {
+      e.preventDefault();
       $('#js-login-modal').attr('aria-expanded', 'false');
-    }
-    $('#js-login-modal').fadeToggle(200);
-  });
+      $('#js-login-modal').fadeToggle(200);
+    });
 
-  // Close when close icon is clicked
+    // Close when form is submitted
 
-  $('#js-login-modal__close').click(function (e) {
-    e.preventDefault();
-    $('#js-login-modal').attr('aria-expanded', 'false');
-    $('#js-login-modal').fadeToggle(200);
-  });
-
-  // Close when form is submitted
-
-  $('#js-login-modal__form').submit(function () {
-    $('#js-login-modal').attr('aria-expanded', 'false');
-    $('#js-login-modal').fadeToggle(200);
-  });
-*/
+    $('#js-login-modal__form').submit(function () {
+      $('#js-login-modal').attr('aria-expanded', 'false');
+      $('#js-login-modal').fadeToggle(200);
+    });
+  */
 
 }); // Close $(document).ready(function()
 
@@ -30998,14 +30998,18 @@ document.addEventListener('DOMContentLoaded', () => {
 });
 
 
-
 // ***** Modal Login ***** //
 document.addEventListener('DOMContentLoaded', () => {
   const modal = document.getElementById('js-login-modal');
-  const closeButton = document.getElementById('js-login-modal__close');
+  const closeButton = document.getElementById('js-login-modal__close').parentElement;
   const formElements = modal.querySelectorAll('input, button, a');
   const firstFocusable = formElements[0];
   const lastFocusable = formElements[formElements.length - 1];
+  const openButton = document.getElementById('js-header__loginout-button');
+
+  // Ensure aria-expanded is set to false initially
+  modal.setAttribute('aria-expanded', 'false');
+  modal.style.display = 'none';
 
   const openModal = () => {
     modal.setAttribute('aria-expanded', 'true');
@@ -31022,6 +31026,7 @@ document.addEventListener('DOMContentLoaded', () => {
     modal.setAttribute('aria-expanded', 'false');
     modal.style.display = 'none';
     // modal.classList.remove('open');
+    openButton.focus();
   };
 
   const handleKeydown = (event) => {
@@ -31030,33 +31035,46 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     if (event.key === 'Tab') {
-      // Manage focus trapping
+      // Allow tabbing outside and close modal if tabbing out
       if (event.shiftKey) {
         // Shift + Tab: focus backwards
         if (document.activeElement === firstFocusable) {
-          event.preventDefault();
-          lastFocusable.focus();
+          closeModal();
         }
       } else {
         // Tab: focus forwards
         if (document.activeElement === lastFocusable) {
-          event.preventDefault();
-          firstFocusable.focus();
+          closeModal();
         }
       }
     }
   };
 
   // Add event listeners
+  // Close modal when clicking outside
+  document.addEventListener('click', (event) => {
+    console.log("event target", event.target);
+    console.log("contains event target", modal.contains(event.target))
+    if (!modal.contains(event.target) && event.target !== openButton &&
+        modal.getAttribute('aria-expanded') === 'true') {
+      closeModal();
+    }
+  });
+
   closeButton.addEventListener('click', closeModal);
+  closeButton.addEventListener('keydown', (event) => {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      closeModal(event);
+    }
+  });
   document.addEventListener('keydown', handleKeydown);
 
-  const openButton = document.getElementById('js-header__loginout-button');
+
   if (openButton) {
     openButton.addEventListener('click', () => {
       const expanded = modal.getAttribute('aria-expanded');
       if (expanded === null || expanded === 'false') {
-        console.log("Opening modal");
         openModal();
       } else {
         closeModal();
@@ -31064,3 +31082,4 @@ document.addEventListener('DOMContentLoaded', () => {
     });
   }
 });
+

--- a/templates/includes/login-modal.html
+++ b/templates/includes/login-modal.html
@@ -1,5 +1,5 @@
 {% load layout_extras %}
-<div id="js-login-modal" class="login-modal" aria-hidden="true" role="dialog" aria-labelledby="login-modal__title">
+<div id="js-login-modal" class="login-modal" aria-expanded="false" role="dialog" aria-labelledby="login-modal__title">
   <div class="login-modal__header">
     <div id="login-modal__title" class="login-modal__title">Access your account</div>
     <a href="" aria-label="Close login modal" role="button">

--- a/templates/includes/top.html
+++ b/templates/includes/top.html
@@ -23,7 +23,7 @@ Welcome {{ authenticatedUser.username }}!
     <img src="/static/images/mobile-menu.svg" alt="Show or hide navigation" class="header__nav-button-icon">
   </button>
 
-  <nav role="navigation" id="js-header__nav" class="header__nav--selected" aria-hidden="false">
+  <nav role="navigation" id="js-header__nav" class="header__nav--selected">
     <a class="header__nav-item-search" href="/search">Search</a>
     <details id="header__nav-details-learn" aria-expanded="false" aria-label="Learn about EZID">
       <summary class="header__nav-item-learn" role="button">Learn</summary>


### PR DESCRIPTION
Addresses #823, #824 -- navigation menus and aria hidden

The login form that opened up had a similar problem to the menu that was hard to dismiss and it also reloaded the page when trying to close, so fixed that, also.

I also added to the gulp build so that Javascript is updated after modified and rebuilt.  Before you had to copy to the correct place manually, which I didn't see the point of and this makes modifying and testing much easier than taking so many steps manually every time.