### PR TITLE
677 refactor expunge v2

### DIFF
--- a/ezidapp/management/commands/proc-expunge_v2.py
+++ b/ezidapp/management/commands/proc-expunge_v2.py
@@ -1,0 +1,239 @@
+#! /usr/bin/env python
+
+#  Copyright©2024, Regents of the University of California
+#  http://creativecommons.org/licenses/BSD
+
+"""Expunge expired test identifiers
+
+Test identifiers older than two weeks are discovered by querying the database directly, but expunged by
+requesting that the (live) EZID server delete them.
+"""
+
+import logging
+import argparse
+import time
+from datetime import datetime
+from dateutil.parser import parse
+
+import django.conf
+import django.conf
+import django.db
+import django.db.transaction
+
+import ezidapp.management.commands.proc_base
+import ezidapp.models.identifier
+import ezidapp.models.identifier
+import ezidapp.models.news_feed
+import ezidapp.models.shoulder
+from django.db.models import Q
+
+import impl.enqueue
+import impl.ezid
+import impl.nog_sql.util
+
+
+log = logging.getLogger(__name__)
+
+
+class Command(django.core.management.BaseCommand):
+    help = __doc__
+    name = __name__
+
+
+    def __init__(self):
+        super(Command, self).__init__()
+        self.opt = None
+        self.min_age_ts = None
+        self.max_age_ts = None
+        self.min_id = None
+        self.max_id = None
+        self.time_range = None
+        self.time_range_str = None
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--pagesize', help='Rows in each batch select.', type=int)
+
+        parser.add_argument(
+            '--created_range_from', type=str,
+            help = (
+                'Created date range from - local date/time in ISO 8601 format without timezone \n'
+                'YYYYMMDD, YYYYMMDDTHHMMSS, YYYY-MM-DD, YYYY-MM-DDTHH:MM:SS. \n'
+                'Examples: 20241001, 20241001T131001, 2024-10-01, 2024-10-01T13:10:01 or 2024-10-01'
+            )
+        )
+        
+        parser.add_argument(
+            '--created_range_to', type=str,
+            help = (
+                'Created date range to - local date/time in ISO 8601 format without timezone \n'
+                'YYYYMMDD, YYYYMMDDTHHMMSS, YYYY-MM-DD, YYYY-MM-DDTHH:MM:SS. \n'
+                'Examples: 20241001, 20241001T131001, 2024-10-01, 2024-10-01T13:10:01 or 2024-10-01'
+            )
+        )
+
+        parser.add_argument(
+            '--debug',
+            action='store_true',
+            help='Debug level logging',
+        )
+    
+    def handle(self, *_, **opt):
+        self.opt = opt = argparse.Namespace(**opt)
+        impl.nog_sql.util.log_setup(__name__, opt.debug)
+
+        BATCH_SIZE = self.opt.pagesize
+        if BATCH_SIZE is None:
+            BATCH_SIZE = 1000
+        
+        # default scan window: 1 day
+        SCAN_WINDOW_IN_SEC = 24 * 60 * 60
+        
+        created_from = None
+        created_to = None
+        created_from_str = self.opt.created_range_from
+        created_to_str = self.opt.created_range_to
+        if created_from_str is not None:
+            try:
+                created_from = self.date_to_seconds(created_from_str)
+            except Exception as ex:
+                log.error(f"Input date/time error: {ex}")
+                exit()
+        if created_to_str is not None:
+            try:
+                created_to = self.date_to_seconds(created_to_str)
+            except Exception as ex:
+                log.error(f"Input date/time error: {ex}")
+                exit()
+        
+        if created_from is not None and created_to is not None:
+            if created_from >= created_to:
+                log.error(f"Created_from date/time {created_from} should be earlier than created_to date/time {created_to}")
+                exit()
+            self.min_age_ts = created_from
+            self.max_age_ts = created_to
+            self.time_range_str = f"between: {created_from_str} and {created_to_str}"
+            self.time_range = Q(createTime__gte=created_from) & Q(createTime__lte=created_to)
+        elif created_to is not None:
+            self.max_age_ts = created_to
+            self.time_range_str = f"before: {created_to_str}"
+            self.time_range = Q(createTime__lte=created_to)
+        else:
+            midnight = datetime.today().replace(hour=0, minute=0, second=0, microsecond=0)
+            self.max_age_ts = int(midnight.timestamp()) - django.conf.settings.DAEMONS_EXPUNGE_MAX_AGE_SEC
+            self.min_age_ts = self.max_age_ts - SCAN_WINDOW_IN_SEC
+            self.time_range_str = f"between: {self.seconds_to_date(self.min_age_ts)} and {self.seconds_to_date(self.max_age_ts)}"
+            self.time_range = Q(createTime__gte=self.min_age_ts) & Q(createTime__lte=self.max_age_ts)
+        
+        self.min_id, self.max_id = self.get_id_range_by_time(self.time_range)
+
+        log.info(f"Initial time range: {self.time_range_str}, {self.time_range}")
+        log.info(f"Initial ID range: {self.min_id} : {self.max_id}")
+
+        while not self.terminated():
+            # TODO: This is a heavy query which can be optimized with better indexes or
+            # flags in the DB.
+            filter_by_id = None
+            if self.min_id is not None:
+                filter_by_id = Q(id__gte=self.min_id)
+            if self.max_id is not None:
+                if filter_by_id is not None:
+                    filter_by_id &= Q(id__lte=self.max_id)
+                else:
+                    filter_by_id = Q(id__lte=self.max_id)
+            
+            combined_filter = (
+                    Q(identifier__startswith=django.conf.settings.SHOULDERS_ARK_TEST)
+                    | Q(identifier__startswith=django.conf.settings.SHOULDERS_DOI_TEST)
+                    | Q(identifier__startswith=django.conf.settings.SHOULDERS_CROSSREF_TEST)
+                )
+            if filter_by_id is not None:
+                combined_filter &= filter_by_id
+            else:
+                log.info(f"No records returned for time range: {self.time_range_str}, {self.time_range}")
+                if created_from is not None or created_to is not None:
+                    log.info("End of processing.")
+                    exit()
+
+            log.info(f"filter: {combined_filter}")
+            try:
+                qs = (
+                    ezidapp.models.identifier.Identifier.objects.filter(combined_filter)
+                        .order_by("id")[: BATCH_SIZE]
+                )
+
+                log.info(f"Query returned {len(qs)} records.")
+                for si in qs:
+                    self.min_id = si.id
+                    with django.db.transaction.atomic():
+                        impl.enqueue.enqueue(si, "delete", updateExternalServices=True)
+                        si.delete()
+
+                if len(qs) < BATCH_SIZE:
+                    log.info(f"Finished time range: {self.time_range_str}, {self.time_range}")
+                    log.info("End of processing")
+                    exit()
+                else:
+                    time.sleep(django.conf.settings.DAEMONS_BATCH_SLEEP)
+            except Exception as ex:
+                log.error(f"Database error: {ex}")
+
+
+    def get_id_range_by_time(self, time_range: Q):
+        first_id = last_id = None
+        
+        if time_range is not None:
+            try:
+                queryset = (
+                    ezidapp.models.identifier.Identifier.objects
+                    .filter(time_range).only("id").order_by("id")
+                )
+                
+                first_record = queryset.first()
+                last_record = queryset.last()
+                
+                if first_record is not None:
+                    first_id = first_record.id
+
+                if last_record is not None:
+                    last_id = last_record.id
+            except Exception as ex:
+                log.error(f"Database error while retrieving records from Identifier for time range: {time_range} : {ex}")
+                # add retry logic here
+        
+        return first_id, last_id
+
+    def date_to_seconds(self, date_time_str: str) -> int:
+        """
+        Convert date/time string to seconds since the Epotch.
+        For example:
+        2024-01-01 00:00:00 => 1704096000
+        2024-10-10 00:00:00 => 1728543600
+
+        Parameter:
+        date_time_str: A date/time string in in ISO 8601 format without timezone.
+        For example: 'YYYYMMDD, YYYYMMDDTHHMMSS, YYYY-MM-DD, YYYY-MM-DDTHH:MM:SS.
+
+        Returns:
+        int: seconds since the Epotch
+
+        """
+
+        # Parse the date and time string to a datetime object
+        dt_object = parse(date_time_str)
+
+        # Convert the datetime object to seconds since the Epoch
+        seconds_since_epoch = int(dt_object.timestamp())
+
+        return seconds_since_epoch
+
+   
+    def seconds_to_date(self, seconds_since_epoch: int) -> str:
+        dt_object = datetime.fromtimestamp(seconds_since_epoch)
+
+        # Format the datetime object to a string in the desired format
+        formatted_time = dt_object.strftime("%Y-%m-%dT%H:%M:%S")
+        return formatted_time
+    
+
+

--- a/ezidapp/management/commands/proc-expunge_v2.py
+++ b/ezidapp/management/commands/proc-expunge_v2.py
@@ -98,7 +98,7 @@ class Command(django.core.management.BaseCommand):
         
         self.start_time = datetime.now()
 
-        log.info(f"expunge started: {self.start_time}")
+        log.info(f"Expunge started: {self.start_time}")
         log.info(f"created_range_from: {created_from_str}")
         log.info(f"created_range_to: {created_to_str}")
         
@@ -121,6 +121,7 @@ class Command(django.core.management.BaseCommand):
             log.error(f"The created_range_from and created_range_to options should be provied in pairs.")
             exit()
 
+        log.info(f"Get identifier's ID range by time range:")
         min_id, max_id = self.get_id_range_by_time(time_range)
 
         log.info(f"Initial time range: {time_range_str}, {time_range}")
@@ -193,7 +194,8 @@ class Command(django.core.management.BaseCommand):
                 if last_record is not None:
                     last_id = last_record.id
             except Exception as ex:
-                log.error(f"Database error while retrieving records from Identifier for time range: {time_range} : {ex}")
+                error_msg = f"Database error while retrieving records from Identifier for time range: {time_range} : {ex}"
+                self.exit_proc(error_msg, error=1)
         
         return first_id, last_id
 
@@ -235,8 +237,8 @@ class Command(django.core.management.BaseCommand):
             log.error(message)
         else:
             log.info(message)
-        log.info(f"expunge ended: {end_time}")
-        log.info(f"execution time: {end_time - self.start_time}")
+        log.info(f"Expunge ended: {end_time}")
+        log.info(f"Execution time: {end_time - self.start_time}")
         exit()
     
 

--- a/ezidapp/management/commands/proc-expunge_v2.py
+++ b/ezidapp/management/commands/proc-expunge_v2.py
@@ -78,10 +78,7 @@ class Command(django.core.management.BaseCommand):
         BATCH_SIZE = options.batchsize
         if BATCH_SIZE is None:
             BATCH_SIZE = 1000
-        
-        # default scan window: 1 day
-        SCAN_WINDOW_IN_SEC = 24 * 60 * 60
-        
+                
         created_from_ts = None
         created_to_ts = None
         created_from_str = options.created_range_from
@@ -112,11 +109,9 @@ class Command(django.core.management.BaseCommand):
         elif created_from_ts is None and created_to_ts is None:
             log.info(f"Setup default time range.")
             expunge_max_age_days = django.conf.settings.DAEMONS_EXPUNGE_MAX_AGE_SEC / (60 * 60 * 24)
-            created_to_date = date.today() - timedelta(days=expunge_max_age_days)
-            # midnight_time in YYYY-MM-DD 00:00:00
-            midnight_time = datetime.combine(created_to_date, datetime.min.time())
-            created_to_ts = int(midnight_time.timestamp())
-            created_from_ts = created_to_ts - SCAN_WINDOW_IN_SEC
+            expunge_date = date.today() - timedelta(days=expunge_max_age_days + 1)
+            created_from_ts = int(datetime.combine(expunge_date, datetime.min.time()).timestamp())
+            created_to_ts = int(datetime.combine(expunge_date, datetime.max.time()).timestamp())
             time_range_str = f"between: {self.seconds_to_date(created_from_ts)} and {self.seconds_to_date(created_to_ts)}"
             time_range = Q(createTime__gte=created_from_ts) & Q(createTime__lte=created_to_ts)      
         else:


### PR DESCRIPTION
@sfisher Hi Scott,
This is the cron version of the expunge which deletes test identifiers that are two weeks old. There are no changes to the core record deleting workflow which uses the EZID queues. Here are new features:
* changed from daemon mode to cron
* limit the select query to a specific time range 
  * default date/time range: one day that is 2 weeks from today
  * defined date/time range: provided through command parameters
* the default batch size for each query is 1000; you can define the batch size using the command parameter
* a function `get_id_range_by_time()` is defined to get the identifiers' ID range from the created time range.  The ID ranges are used for each batch select query.

Tests:
* tested on ezid-dev and ezid-stg. 
* test log can be found in ticket #677 
  * [comments after this one are all test test related](https://github.com/CDLUC3/ezid/issues/677#issuecomment-2725281569)

Here are the command paramters:
python manage.py proc-expunge_v2 --help
```
--batchsize BATCHSIZE
                        Rows in each batch select.
  --created_range_from CREATED_RANGE_FROM
                        Created date range from - local date/time in ISO 8601 format without timezone YYYYMMDD,
                        YYYYMMDDTHHMMSS, YYYY-MM-DD, YYYY-MM-DDTHH:MM:SS. Examples: 20241001, 20241001T131001,
                        2024-10-01, 2024-10-01T13:10:01 or 2024-10-01
  --created_range_to CREATED_RANGE_TO
                        Created date range to - local date/time in ISO 8601 format without timezone YYYYMMDD,
                        YYYYMMDDTHHMMSS, YYYY-MM-DD, YYYY-MM-DDTHH:MM:SS. Examples: 20241001, 20241001T131001,
                        2024-10-01, 2024-10-01T13:10:01 or 2024-10-01
```

Please review and let me know if you have questions.

Thank you

Jing