### PR TITLE
change log from error to info for create or update if id exists

### DIFF
--- a/impl/ezid.py
+++ b/impl/ezid.py
@@ -297,12 +297,13 @@ def createIdentifier(identifier, user, metadata=None, updateIfExists=False):
         impl.log.badRequest(tid)
         return "error: bad request - " + impl.util.formatValidationError(e)
     except django.db.utils.IntegrityError as e:
-        logger.error(str(e))
-        impl.log.badRequest(tid)
         if updateIfExists:
+            logger.info(f"create or update with update_if_exists=yes; identifier already exists, update; identifier={identifier}")
             return setMetadata(identifier, user, metadata, internalCall=True)
         else:
-            return "error: bad request - identifier already exists"
+            logger.error(str(e))
+            impl.log.badRequest(tid)
+            return "error: bad request - identifier already exists, cannot create"
     except Exception as e:
         impl.log.error(tid, e)
         if hasattr(sys, 'is_running_under_pytest'):


### PR DESCRIPTION
@sfisher Hi Scott,
This refactoring is to change log level from error to info for the "create or update when identifier exists" option. 

To test:
1.  create a test identifier, for example `ark:/99999/fk4h14jm0s`
2. perform a "create or update if exists" operation on this identifier with a PUT request on `id/ark:/99999/fk4h14jm0s?update_if_exists=yes` -  success response is expected.

3. perform a create request with PUT method without the `update_if_exists=yes` parameter `id/ark:/99999/fk4h14jm0s` - an error is expected "error: bad request - identifier already exists, cannot create"

Testing on my local Mac against the ezid-dev database looks good.

Please take a look and let me know if you have question.

Thank you

Jing