### PR TITLE
update dependencies after python upgrade

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -34,17 +34,17 @@ tests = ["mypy (>=0.800)", "pytest", "pytest-asyncio"]
 
 [[package]]
 name = "boto3"
-version = "1.37.19"
+version = "1.37.26"
 description = "The AWS SDK for Python"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "boto3-1.37.19-py3-none-any.whl", hash = "sha256:fbfc2c43ad686b63c8aa02aee634c269f856eed68941d8e570cc45950be52130"},
-    {file = "boto3-1.37.19.tar.gz", hash = "sha256:c69c90500f18fd72d782d1612170b7d3db9a98ed51a4da3bebe38e693497ebf8"},
+    {file = "boto3-1.37.26-py3-none-any.whl", hash = "sha256:77ff13723ad5b836a565c382610c3994e14ce643144dc9c604bfe1efb3213739"},
+    {file = "boto3-1.37.26.tar.gz", hash = "sha256:78fb57556c2337e087d2eda419ee371b52843a2420861114413791113efeabe2"},
 ]
 
 [package.dependencies]
-botocore = ">=1.37.19,<1.38.0"
+botocore = ">=1.37.26,<1.38.0"
 jmespath = ">=0.7.1,<2.0.0"
 s3transfer = ">=0.11.0,<0.12.0"
 
@@ -53,13 +53,13 @@ crt = ["botocore[crt] (>=1.21.0,<2.0a0)"]
 
 [[package]]
 name = "botocore"
-version = "1.37.19"
+version = "1.37.26"
 description = "Low-level, data-driven core of boto 3."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "botocore-1.37.19-py3-none-any.whl", hash = "sha256:6e1337e73a6b8146c1ec20a6a72d67e2809bd4c0af076431fe6e1561e0c89415"},
-    {file = "botocore-1.37.19.tar.gz", hash = "sha256:eadcdc37de09df25cf1e62e8106660c61f60a68e984acfc1a8d43fb6267e53b8"},
+    {file = "botocore-1.37.26-py3-none-any.whl", hash = "sha256:d499a617903cbcaae18380320125fa3a95cb625b613d746e6edc69c6f01f1326"},
+    {file = "botocore-1.37.26.tar.gz", hash = "sha256:7f6dc999e7a34c0917623aac67c9ea2389b741bb7babee1a88cf2cd04006ea7a"},
 ]
 
 [package.dependencies]


### PR DESCRIPTION
@sfisher Hi Scott,
The Python 3.11.11 upgrade is performed by the puppet deployment script. What we need to do is to modify the puppet configuration files and change the virtual environment variable `python_version` value from `3.11.9` to `3.11.11`. 

Detailed procedure is documented in the [EZID-docs-internal repo How to upgrade Python](https://github.com/CDLUC3/ezid-docs-internal/blob/main/docs/how_to_upgrade_python.md).

The `poetry.lock` file was produced by the `poetry update` command after Python 3.11.11 upgrade.

Puppet configuration:
```
diff --git a/node/uc3-ezidui-stg01.cdlib.org.yaml b/node/uc3-ezidui-stg01.cdlib.org.yaml
index 6b4dd83..830ef34 100644
--- a/node/uc3-ezidui-stg01.cdlib.org.yaml
+++ b/node/uc3-ezidui-stg01.cdlib.org.yaml
@@ -4,11 +4,11 @@
 uc3_ezid_ui::config:
   staging:
     deployment_level: 'settings'
-    project_revision: 'v3.3.6'
+    project_revision: 'test-python3.11.11-v1'
     scripts_revision: 'v0.0.9'
     run_ansible: true
     virtual_environments:
-    - python_version: '3.11.9'
+    - python_version: '3.11.11'
       pyenv_name: 'ezid-py311'
     pyenv_global: 'ezid-py311'
```

Tests in the ezid stage environment (on tag `test-python3.11.11-v1`) look good. Test results are recorded in ticket [Upgrade Python to 3.11.11 for EZID](https://github.com/CDLUC3/ezid/issues/849)

Please review and let me know if you have questions.

Thank you

Jing
