### PR TITLE
Remove the background hint arrow

### DIFF
--- a/dev/scss/_home.scss
+++ b/dev/scss/_home.scss
@@ -53,7 +53,7 @@
 		width: 100%;
 		margin: 30px 15px;
 		padding: 30px 50px 0;
-		background-image: url('../images/arrow.png');
+		// background-image: url('../images/arrow.png');  // no longer desired
 		background-repeat: no-repeat;
 		background-position: top 27px left -8px;
 	}

--- a/static_src/stylesheets/main2.min.css
+++ b/static_src/stylesheets/main2.min.css
@@ -2367,7 +2367,6 @@ Selector pattern using above mixin:
       width: 100%;
       margin: 30px 15px;
       padding: 30px 50px 0;
-      background-image: url("../images/arrow.png");
       background-repeat: no-repeat;
       background-position: top 27px left -8px; } }
 


### PR DESCRIPTION
from the "see how easy it is" demo.

It looks a lot cleaner without it.

Tested on dev, also and arrow is gone. :-)
