### PR TITLE
Refactor link checker to enable exclusion by shoulder

### DIFF
--- a/ezidapp/management/commands/proc-link-checker.py
+++ b/ezidapp/management/commands/proc-link-checker.py
@@ -60,6 +60,25 @@ its identifiers and target URLs are not entered into the link checker's table at
 
 The link checker notices within a few seconds when the exclusion file has been modified.
 Examine the link checker's log file to confirm that it has been reloaded successfully.
+
+There is also the option to exclude identifiers based on a regular expression which will
+usually be used to exclude shoulders, but can be more flexible if needed. These
+variables in the settings file control this behavior:
+
+    LINKCHECKER_ID_EXCLUSION_ENABLED = True
+    LINKCHECKER_ID_EXCLUSION_FILE = 'path/to/id_exclusion_file.txt'
+
+The id exclusion file should contain regular expression patterns, one per line, that
+match identifiers to be excluded. Lines starting with '#' or empty lines are ignored.
+
+The regular expressions are case-insensitive and would typically be things such as
+`^ark:/13030/c8` which anchor at the beginning of the identifier for shoulder matching.
+
+The regular expressions are combined into a single regex pattern that is used for matching any (|).
+This approach should work for a moderate number of patterns (say less than 1,000) and if we have large
+numbers of patterns, we may need to consider a different approach because performance may degrade.
+I suspect that only a limited number of patterns (shoulders) will be needed for exclusion in practice
+so we will likely not need to worry about performance issues from having too many patterns.
 """
 
 # noinspection PyUnresolvedReferences

--- a/ezidapp/management/commands/proc-link-checker.py
+++ b/ezidapp/management/commands/proc-link-checker.py
@@ -61,17 +61,11 @@ its identifiers and target URLs are not entered into the link checker's table at
 The link checker notices within a few seconds when the exclusion file has been modified.
 Examine the link checker's log file to confirm that it has been reloaded successfully.
 
-There is also the option to exclude identifiers based on a regular expression which will
-usually be used to exclude shoulders, but can be more flexible if needed. These
-variables in the settings file control this behavior:
+There is also the option to exclude identifiers based on what they start with which will
+usually be used to exclude shoulders.
 
     LINKCHECKER_ID_EXCLUSION_ENABLED = True
     LINKCHECKER_ID_EXCLUSION_FILE = 'path/to/id_exclusion_file.txt'
-
-The id exclusion file should contain shoulder patterns that match identifiers. Such as `ark:/13030/c8`
-blank lines and comment lines starting with `#` are ignored.
-
-internally things are compiled into a regular expression to check (probably performs fast up to about 1,000 exclusions or maybe more).
 """
 
 # noinspection PyUnresolvedReferences

--- a/settings/settings.py.j2
+++ b/settings/settings.py.j2
@@ -529,9 +529,14 @@ LINKCHECKER_MAX_READ = 104_857_600
 # EZID Link checker e-mails
 LINK_CHECKER_ADMIN = {{ link_checker_admin }}
 LINKCHECKER_EXCLUSION_ENABLED = True
+LINKCHECKER_ID_EXCLUSION_ENABLED = True
 # Full path to the file containing the list of user accounts to be excluded from link checking.
 # None or empty string means no exclusion file.
 LINKCHECKER_EXCLUSION_FILE = DATA_DIR / 'link_check_exclusion_list.txt'
+# the ID exclusion file contains regex patterns that match identifiers to be excluded, which
+# will ususally be the beginning "shoulder" of the identifier, but could be something else and get regex
+# ORed together to check for exclusion in one pass by the link checker.
+LINKCHECKER_ID_EXCLUSION_FILE = DATA_DIR / 'linkchecker_id_exclusion_list.txt'
 
 # Internal settings
 

--- a/settings/settings.py.j2
+++ b/settings/settings.py.j2
@@ -533,9 +533,8 @@ LINKCHECKER_ID_EXCLUSION_ENABLED = True
 # Full path to the file containing the list of user accounts to be excluded from link checking.
 # None or empty string means no exclusion file.
 LINKCHECKER_EXCLUSION_FILE = DATA_DIR / 'link_check_exclusion_list.txt'
-# the ID exclusion file contains regex patterns that match identifiers to be excluded, which
-# will ususally be the beginning "shoulder" of the identifier, but could be something else and get regex
-# ORed together to check for exclusion in one pass by the link checker.
+
+# the ID exclusion file contains startswith identifier patterns to be excluded.
 LINKCHECKER_ID_EXCLUSION_FILE = DATA_DIR / 'linkchecker_id_exclusion_list.txt'
 
 # Internal settings


### PR DESCRIPTION
This allows exclusion by regex, which would be the same as shoulder if using a regex like `^ark:/13030/c8` which anchors at the beginning of the identifier string.  It allows us flexibility if we need to do more involved exclusion later but works for this use case.

I tried to follow the patterns already being used in these files.

I'm not sure about how to test this out, so I'll mark as a draft PR until we can discuss and I can run through that testing.

I'm also not sure about reporting from the link checker.  I think this is an unknown task right now (about how reporting should be affected) and my belong in it's own task if we're overhauling it (and some users are already excluded and I'm not sure how that works with reporting).

