### PR TITLE
Unexpected change of context errors

### DIFF
--- a/impl/ui_create.py
+++ b/impl/ui_create.py
@@ -121,6 +121,8 @@ def simple_form(request, d):
             d['current_profile'], d['form_placeholder'], None
         )
         d['id_gen_result'] = 'edit_page'
+        if 'anchor' in REQUEST:
+            d['anchor'] = REQUEST['anchor']
     else:
         if "current_profile" not in REQUEST or "shoulder" not in REQUEST:
             d['id_gen_result'] = 'bad_request'

--- a/static_src/javascripts/advanced_create.js
+++ b/static_src/javascripts/advanced_create.js
@@ -13,7 +13,7 @@ $(document).ready(function() {
     document.getElementById('tab-1').checked = false;
     document.getElementById('tab-2').checked = true;
     var action = location.pathname.split("/")[1];  // Handle create or demo pages
-    window.location.href = "/" + action + "/simple";
+    window.location.href = "/" + action + "/simple#tab-1-label";
   }
   // Act on keyboard enter or spacebar
   $("#tab-1-label").keyup(function(e){

--- a/static_src/javascripts/advanced_create.js
+++ b/static_src/javascripts/advanced_create.js
@@ -40,6 +40,7 @@ $(document).ready(function() {
   // submit form when shoulder changes
   $("input[name=shoulder]").change(function(e) {
       var new_scheme = e.target.value.split(':')[0];
+      const target_id = e.target.id;
       if(orig_scheme.split(':')[0] != new_scheme){
         // changing scheme
           if(new_scheme == 'doi'){
@@ -47,7 +48,7 @@ $(document).ready(function() {
           }else{
               $('#current_profile').val('erc');
           }
-          do_get();
+          do_get(target_id);  // submit form with new profile, and the target id is the element the user was on for returning
       }
       orig_scheme = e.target.value;
   });
@@ -75,8 +76,7 @@ $(document).ready(function() {
 
   // submit form when profile changes
   $("#current_profile").bind("change", function(event){
-      var includeAnchor = true;
-      do_get(includeAnchor);
+      do_get('current_profile');
   });
 
   // When user submits:
@@ -100,15 +100,14 @@ $(document).ready(function() {
   });
 
 
-// ***** Submit form when profile or shoulder changes ******* //
-
+  // ***** Submit form when profile or shoulder changes ******* //
   // If triggered by profile, then, after submission, scroll page down to specified anchor
   function do_get(includeAnchor){
       var frm = $('#create_form');
       frm.attr('action', location.pathname + '?publish=' +
         $("[name='publish']").val() + '&remainder=' + $("#remainder").val());
       if (includeAnchor) {
-        var input = $("<input>", { type: "hidden", name: "anchor", value: "current_profile" });
+        var input = $("<input>", { type: "hidden", name: "anchor", value: includeAnchor});
         frm.append($(input));
       }
       frm.unbind('submit');

--- a/static_src/javascripts/simple_create.js
+++ b/static_src/javascripts/simple_create.js
@@ -11,6 +11,7 @@ $(document).ready(function() {
 
   $("input[name=shoulder]").change(function(e) {
     var new_scheme = e.target.value.split(':')[0];
+    const target_id = e.target.id;
     if(orig_val.split(':')[0] != new_scheme){
     // changing scheme
       if(new_scheme == 'doi'){
@@ -18,8 +19,7 @@ $(document).ready(function() {
       }else{
         $('#current_profile').attr('value', 'erc');
       }
-      $('#create_form').attr('method', 'get');
-      $('#create_form').submit();
+      do_get(target_id);  // submit form with new profile, and the target id is the element the user was on for returning
     }
     orig_val = e.target.value;
   });
@@ -43,5 +43,20 @@ $(document).ready(function() {
   $('#tab-2:not(:checked)').on('change', function() {
     actTab2();
   });
+
+  // ***** Submit form when profile or shoulder changes ******* //
+  // If triggered by profile, then, after submission, scroll page down to specified anchor
+  function do_get(includeAnchor){
+      var frm = $('#create_form');
+      frm.attr('action', location.pathname + '?publish=' +
+        $("[name='publish']").val() + '&remainder=' + $("#remainder").val());
+      if (includeAnchor) {
+        var input = $("<input>", { type: "hidden", name: "anchor", value: includeAnchor});
+        frm.append($(input));
+      }
+      frm.unbind('submit');
+      frm.attr('method', 'get');
+      frm.submit();
+  }
 
 });

--- a/static_src/javascripts/simple_create.js
+++ b/static_src/javascripts/simple_create.js
@@ -29,7 +29,7 @@ $(document).ready(function() {
     document.getElementById('tab-2').checked = false;
     document.getElementById('tab-1').checked = true;
     action = location.pathname.split("/")[1];  // Handle create or demo pages
-    window.location.href = "/" + action + "/advanced";
+    window.location.href = "/" + action + "/advanced#tab-2-label";
   }
   // Act on keyboard enter or spacebar
   $("#tab-2-label").keyup(function(e){

--- a/templates/create/advanced.html
+++ b/templates/create/advanced.html
@@ -9,7 +9,7 @@
     <input class="tabnew__input" id="tab-1" type="radio" name="name" aria-checked="false"/>
     <label class="tabnew__label" id="tab-1-label" for="tab-1" tabindex="0">{% trans "Simple" %}</label>
     <input class="tabnew__input" id="tab-2" type="radio" name="name" checked="checked" aria-checked="true"/>
-    <label class="tabnew__label" for="tab-2" tabindex="0">{% trans "Advanced" %}</label>
+    <label class="tabnew__label" id="tab-2-label" for="tab-2" tabindex="0">{% trans "Advanced" %}</label>
   </div>
   <div class="tabnew__content">
     <form id="create_form" action="{% url "ui_create.advanced" %}" method="post" class="form-horizontal" role="form">

--- a/templates/create/simple.html
+++ b/templates/create/simple.html
@@ -8,7 +8,7 @@
 <div class="tabsnew create__tab"> <!-- create__tab is a class that is used in the CSS file -->
   <div class="tabnew__header">
     <input class="tabnew__input" id="tab-1" type="radio" name="name" checked="checked" aria-checked="true"/>
-    <label class="tabnew__label" for="tab-1" tabindex="0">{% trans "Simple" %}</label>
+    <label class="tabnew__label" id="tab-1-label" for="tab-1" tabindex="0">{% trans "Simple" %}</label>
 
     <input class="tabnew__input" id="tab-2" type="radio" name="name" aria-checked="false">
     <label class="tabnew__label" id="tab-2-label" for="tab-2" tabindex="0">{% trans "Advanced" %}</label>

--- a/templates/create/simple.html
+++ b/templates/create/simple.html
@@ -50,4 +50,12 @@
   {% include "info/popup_help.html" %}
   <script type="text/javascript" src="/static/javascripts/help_box_.js"></script>
 
+  {% if anchor %}
+  <script type='text/javascript'>
+  $(document).ready(function(){
+    window.location = '#{{ anchor }}'
+  });
+  </script>
+  {% endif %}
+
 {% endblock %}

--- a/templates/demo/advanced.html
+++ b/templates/demo/advanced.html
@@ -8,17 +8,35 @@
 {% block heading %}{% content_heading _("Create an Advanced Demo Identifier") %}{% endblock %}
 {% block content %}
 {% learn_breadcrumb _('EZID Demo') %}
-<div class="tab create__tab">
-  <!-- This radio button is hidden by CSS -->
-  <input class="tab__input" id="tab-1" type="radio" name="name" aria-checked="false"/>
-  <label class="tab__label" id="tab-1-label" for="tab-1" tabindex="0">{% trans "Simple" %}</label>
-  <input class="tab__input" id="tab-2" type="radio" name="name" checked="checked" aria-checked="true"/>
-  <label class="tab__label" for="tab-2" tabindex="0">{% trans "Advanced" %}</label>
-  <div class="tab__content">
+<div class="tabsnew create__tab">
+  <div class="tabnew__header">
+    <!-- This radio button is hidden by CSS -->
+    <input class="tabnew__input" id="tab-1" type="radio" name="name" aria-checked="false"/>
+    <label class="tabnew__label" id="tab-1-label" for="tab-1" tabindex="0">{% trans "Simple" %}</label>
+    <input class="tabnew__input" id="tab-2" type="radio" name="name" checked="checked" aria-checked="true"/>
+    <label class="tabnew__label" for="tab-2" tabindex="0">{% trans "Advanced" %}</label>
+  </div>
+  <div class="tabnew__content">
     <form id="create_form" action="{% url "ui_demo.advanced" %}" method="post" class="form-horizontal" role="form">
     <input name="action" id="action" type="hidden" value="create"/>
-    <div class="row">
-      <div class="col-md-4 col-md-push-8 create__sidebox">
+    <div class="bs-create__row">
+
+      <!-- main content (top part of form) -->
+      <div class="bs-create__main">
+        {% include "includes/simple_id_type.html" with calling_page="demo" %}
+        {% include "includes/advanced_remainder.html" %}
+        {% include "includes/advanced_publish_id.html" %}
+      </div>
+    </div>
+
+    <!-- rest of the form -->
+    <div class="bs-fieldset-stacked" role="group" aria-labelledby="create__fieldset7">
+      {% include "includes/advanced_describe.html" %}
+      {% include "includes/create_button.html" with calling_page="demo" id_type="advanced" %} 
+    </div>
+
+      <!-- sidebar -->
+      <div class="bs-create__sidebox">
         <div class="sidebox">
           <h2 class="sidebox__heading">{% trans "Quick Start Guides for Demo IDs" %}</h2>
           <ul class="sidebox__list">
@@ -31,20 +49,6 @@
           </ul>
         </div>
       </div>
-      <div class="col-md-8 col-md-pull-4">
-        {% include "includes/simple_id_type.html" with calling_page="demo" %}
-        {% include "includes/advanced_remainder.html" %}
-        {% include "includes/advanced_publish_id.html" %}
-      </div>
-    </div>
-
-    <div class="fieldset-stacked" role="group" aria-labelledby="create__fieldset7">
-
-      {% include "includes/advanced_describe.html" %} 
-     
-      {% include "includes/create_button.html" with calling_page="demo" id_type="advanced" %} 
-
-    </div>
     </form>
   </div>
 </div>

--- a/templates/demo/advanced.html
+++ b/templates/demo/advanced.html
@@ -14,7 +14,7 @@
     <input class="tabnew__input" id="tab-1" type="radio" name="name" aria-checked="false"/>
     <label class="tabnew__label" id="tab-1-label" for="tab-1" tabindex="0">{% trans "Simple" %}</label>
     <input class="tabnew__input" id="tab-2" type="radio" name="name" checked="checked" aria-checked="true"/>
-    <label class="tabnew__label" for="tab-2" tabindex="0">{% trans "Advanced" %}</label>
+    <label class="tabnew__label" id="tab-2-label" for="tab-2" tabindex="0">{% trans "Advanced" %}</label>
   </div>
   <div class="tabnew__content">
     <form id="create_form" action="{% url "ui_demo.advanced" %}" method="post" class="form-horizontal" role="form">

--- a/templates/demo/simple.html
+++ b/templates/demo/simple.html
@@ -10,7 +10,7 @@
 <div class="tabsnew create__tab">
   <div class="tabnew__header">
     <input class="tabnew__input" id="tab-1" type="radio" name="name" checked="checked" aria-checked="true"/>
-    <label class="tabnew__label" for="tab-1" tabindex="0">{% trans "Simple" %}</label>
+    <label class="tabnew__label" id="tab-1-label" for="tab-1" tabindex="0">{% trans "Simple" %}</label>
 
     <input class="tabnew__input" id="tab-2" type="radio" name="name" aria-checked="false">
     <label class="tabnew__label" id="tab-2-label" for="tab-2" tabindex="0">{% trans "Advanced" %}</label>

--- a/templates/demo/simple.html
+++ b/templates/demo/simple.html
@@ -7,37 +7,43 @@
 {% block heading %}{% content_heading _("Create a Simple Demo Identifier") %}{% endblock %}
 {% block content %}
 {% learn_breadcrumb _('EZID Demo') %}
-<div class="tab create__tab">
-  <input class="tab__input" id="tab-1" type="radio" name="name" checked="checked" aria-checked="true"/>
-  <label class="tab__label" for="tab-1" tabindex="0">{% trans "Simple" %}</label>
-  <div class="tab__content">
+<div class="tabsnew create__tab">
+  <div class="tabnew__header">
+    <input class="tabnew__input" id="tab-1" type="radio" name="name" checked="checked" aria-checked="true"/>
+    <label class="tabnew__label" for="tab-1" tabindex="0">{% trans "Simple" %}</label>
+
+    <input class="tabnew__input" id="tab-2" type="radio" name="name" aria-checked="false">
+    <label class="tabnew__label" id="tab-2-label" for="tab-2" tabindex="0">{% trans "Advanced" %}</label>
+  </div>
+  <div class="tabnew__content">
     <form id="create_form" action="{% url "ui_demo.simple" %}" method="post" class="form-horizontal" role="form">
-    <div class="row">
-
-      <div class="col-md-4 col-md-push-8 create__sidebox">
-        <div class="sidebox">
-          <h2 class="sidebox__heading">{% trans "Quick Start Guide for Demo IDs" %}</h2>
-          <ul class="sidebox__list">
-            <li><a href="/static/locale/en/EZID_SimpleCreate.pdf" class="link__primary" title="PDF Document" target="_blank">{% trans "Simple ID Creation" %}</a></li>
-          </ul>
-        </div>
+    <input name="action" id="action" type="hidden" value="create"/>
+    {% csrf_token %}
+    <div class="bs-create__row">
+      <!-- main content (top part of form) -->
+      <div class="bs-create__main">
+        {% include "includes/simple_id_type.html" with calling_page="demo" %}
       </div>
-
-      <div class="col-md-8 col-md-pull-4">
-      {% include "includes/simple_id_type.html" with calling_page="demo" %} 
-      </div>
-
     </div>
 
-    {% include "includes/simple_describe.html" %} 
 
-    {% include "includes/create_button.html" with calling_page="demo" id_type="simple" %} 
+    <!-- rest of the form -->
+    <div class="bs-fieldset-stacked" role="group" aria-labelledby="create__fieldset7">
+      {% include "includes/simple_describe.html" %}
+      {% include "includes/create_button.html" with calling_page="demo" id_type="simple" %}
+    </div>
 
+    <!-- sidebar -->
+    <div class="bs-create__sidebox">
+      <div class="sidebox">
+        <h2 class="sidebox__heading">{% trans "Quick Start Guide for Demo IDs" %}</h2>
+        <ul class="sidebox__list">
+          <li><a href="/static/locale/en/EZID_SimpleCreate.pdf" class="link__primary" title="PDF Document" target="_blank">{% trans "Simple ID Creation" %}</a></li>
+        </ul>
+      </div>
+    </div>
+    </form>
   </div>
-
-  <!-- This radio button is hidden by CSS -->
-  <input class="tab__input" id="tab-2" type="radio" name="name" aria-checked="false">
-  <label class="tab__label" id="tab-2-label" for="tab-2" tabindex="0">{% trans "Advanced" %}</label>
 </div>
 
   <script type="text/javascript" src="/static/javascripts/simple_create.js"></script>

--- a/templates/demo/simple.html
+++ b/templates/demo/simple.html
@@ -51,4 +51,12 @@
   {% include "info/popup_help.html" %}
   <script type="text/javascript" src="/static/javascripts/help_box_.js"></script>
 
+   {% if anchor %}
+  <script type='text/javascript'>
+  $(document).ready(function(){
+    window.location = '#{{ anchor }}'
+  });
+  </script>
+  {% endif %}
+
 {% endblock %} 


### PR DESCRIPTION
I'm bundling all the "change of context" errors within this PR:

- https://github.com/CDLUC3/ezid/issues/919
- https://github.com/CDLUC3/ezid/issues/920

The problem is that the page reloads to change the page content (the old style way) and the place in the page gets lost when using the keyboard.  This applies to the 4 pages demo/simple, demo/advanced, create/simple, create/advanced.

The controls that change the page content are 1) going from Ark to DOI or DOI to ARK, 2) or changing the profile.  Both these reload the page for new contents but weren't going back to the same place in the page afterward in some cases.

Now we should observe that it goes back to where it came from afterward.

A longer term fix may be either using something like AJAX and unobtrusive javascript to reload parts of the page and replace sections of the page (rather than the whole page) or load all the contents for everything (whatever could possibly change) into a massive page and then just hide and show things with Javascript.

I'm a little afraid to go too far down these roads since the forms are complicated, the way the scripts get attached are not always clear and it would be a major change with more possibilities to break functionality along the way, but maybe it's worth doing sometime.

What is here works fine but it's just a little "old school" (and I think I saw some internet Explorer support in there still 😱 ). I think some of the EZID site got created in the early 2010s before the JS frameworks to do this stuff more easily were more common (see also jQuery, which was sort of needed until the browsers got their stuff together and got more compatible with Javascript around 2016 with ES6 when it started getting more adoption).