### PR TITLE
replace serializers.PickleSerializer with JSONSerializer

### DIFF
--- a/settings/settings.py.j2
+++ b/settings/settings.py.j2
@@ -349,7 +349,8 @@ NEWSFEED_POLLING_INTERVAL = 1800
 
 SESSION_COOKIE_AGE = 7 * 24 * 60 * 60
 SESSION_EXPIRE_AT_BROWSER_CLOSE = True
-SESSION_SERIALIZER = 'django.contrib.sessions.serializers.PickleSerializer'
+SESSION_SERIALIZER = 'django.contrib.sessions.serializers.JSONSerializer'
+SESSION_ENGINE = "django.contrib.sessions.backends.db"
 SESSION_COOKIE_PATH = '/'
 
 # EZID administrator account

--- a/settings/tests.py
+++ b/settings/tests.py
@@ -345,7 +345,8 @@ NEWSFEED_POLLING_INTERVAL = 1800
 
 SESSION_COOKIE_AGE = 7 * 24 * 60 * 60
 SESSION_EXPIRE_AT_BROWSER_CLOSE = True
-SESSION_SERIALIZER = 'django.contrib.sessions.serializers.PickleSerializer'
+SESSION_SERIALIZER = 'django.contrib.sessions.serializers.JSONSerializer'
+SESSION_ENGINE = "django.contrib.sessions.backends.db"
 SESSION_COOKIE_PATH = '/'
 
 # EZID administrator account


### PR DESCRIPTION
@sfisher Hi Scott,
This is to replace django.contrib.sessions.serializers.PickleSerializer with JSONSerializer which will be the only session serializer in Django 5.

The `SESSION_ENGINE = "django.contrib.sessions.backends.db` is the default Django setting. I am adding it explicitly so we know that session data is stored in the database in the `django_session` table. 

Please review.

Thank you

Jing