### PR TITLE
Adding accessibility section for "Learn" page and menu.

### DIFF
--- a/dev/includes/header.html
+++ b/dev/includes/header.html
@@ -26,6 +26,7 @@
         <a class="header__nav-subitem" href="/learn#01">What Is EZID?</a>
         <a class="header__nav-subitem" href="/learn#02">Current Users</a>
         <a class="header__nav-subitem" href="/learn#04">Documentation</a>
+        <a class="header__nav-subitem" href="/learn#05">Accessibility</a>
         <a class="header__nav-subitem" href="/learn/doi_services_faq">FAQ</a>
         <a class="header__nav-subitem" href="/doc/apidoc.html">API Guide</a>
         <a class="header__nav-subitem" href="/demo">EZID Demo</a>

--- a/templates/includes/localized/cdl/footer_fineprint.html
+++ b/templates/includes/localized/cdl/footer_fineprint.html
@@ -3,5 +3,5 @@
     <p class="footer__text">© {% now "Y" %} The Regents of the University of California</p>
     <a href="/home/about_us" class="footer__copyright-link">About Us</a>
     <a href="http://www.cdlib.org/about/privacy.html" class="footer__copyright-link">Privacy Policy</a>
-    <a href="http://www.cdlib.org/about/accessibility.html" class="footer__copyright-link">Accessibility Policy</a>
+    <a href="/learn/#05" class="footer__copyright-link">Accessibility Policy</a>
   </div>

--- a/templates/includes/top.html
+++ b/templates/includes/top.html
@@ -31,6 +31,7 @@ Welcome {{ authenticatedUser.username }}!
         <a class="header__nav-subitem" href="{% url "ui_home.learn" %}#01">What Is EZID?</a>
         <a class="header__nav-subitem" href="{% url "ui_home.learn" %}#02">Current Users</a>
         <a class="header__nav-subitem" href="{% url "ui_home.learn" %}#04">Documentation</a>
+        <a class="header__nav-subitem" href="{% url "ui_home.learn" %}#05">Accessibility</a>
         <a class="header__nav-subitem" href="/learn/doi_services_faq">FAQ</a>
         <a class="header__nav-subitem" href="/doc/apidoc.html">API Guide</a>
         <a class="header__nav-subitem" href="{% url "ui_demo.index" %}">EZID Demo</a>

--- a/templates/learn.html
+++ b/templates/learn.html
@@ -32,6 +32,10 @@ $(document).ready(function(){
     <summary class="accordion__title"><h2 class="accordion__title-heading">Documentation</h2></summary>
 {% include "info/learnsub_documentation.html" %}
   </details>
+  <details id="accordion__section-05" class="accordion__section">
+    <summary class="accordion__title"><h2 class="accordion__title-heading">Accessibility</h2></summary>
+{% include "info/learnsub_accessibility.html" %}
+  </details>
   </div>
 
   <a href="/learn/doi_services_faq">


### PR DESCRIPTION
Most of the change is actually in the info-pages repo.  But to make it parallel with the other sections (heading, menu) I have to change things in here, also.

See https://github.com/CDLUC3/ezid/issues/1018 .

I think https://github.com/CDLUC3/ezid-info-pages/pull/3 has to be merged first and then this one merged and then we can test by deploying to development server.

I tested the changes locally (I have two different repos inside my code) and it looks ok to me.

<img width="1138" height="518" alt="Screenshot 2026-05-22 at 1 27 14 PM" src="https://github.com/user-attachments/assets/992debbc-80c2-4cbd-b2e6-90632651c93f" />
<img width="183" height="400" alt="Screenshot 2026-05-22 at 1 27 31 PM" src="https://github.com/user-attachments/assets/20cda1a4-d211-4f93-9c68-566a7653ce91" />

