### PR TITLE
remove version spec for poetry package

### DIFF
--- a/ansible/roles/ezid/tasks/configure_ezid.yaml
+++ b/ansible/roles/ezid/tasks/configure_ezid.yaml
@@ -24,7 +24,7 @@
 
 - name: install poetry
   ansible.builtin.pip:
-    name: poetry==1.8.5
+    name: poetry
 
 - name: run pip install
   ansible.builtin.command:


### PR DESCRIPTION
reverts commit 8ce874b4126f4d56db79cdc80c439eb1ae858eb3
Author: sfisher <scott.fisher@ucop.edu>
Date:   Tue Jan 7 11:00:29 2025 -0800

    I believe this should keep poetry from updating to version 2.x which seems to have some breaking configuration changes currently.  I'll cherry pick this commit into it's own pull request if this works.